### PR TITLE
Throwing Aura exception on ReflectionException

### DIFF
--- a/src/Aura/Di/Config.php
+++ b/src/Aura/Di/Config.php
@@ -123,6 +123,8 @@ class Config implements ConfigInterface
     /**
      * 
      * Returns a \ReflectionClass for a named class.
+     *
+     * @throws Exception\ServiceInvalid In case reflection could not reflect a class
      * 
      * @param string $class The class to reflect on.
      * 
@@ -132,7 +134,11 @@ class Config implements ConfigInterface
     public function getReflect($class)
     {
         if (! isset($this->reflect[$class])) {
-            $this->reflect[$class] = new \ReflectionClass($class);
+            try {
+                $this->reflect[$class] = new \ReflectionClass($class);
+            } catch (\ReflectionException $exception) {
+                throw new Exception\ServiceInvalid("Service class {$class} is invalid", 0, $exception);
+            }
         }
         return $this->reflect[$class];
     }

--- a/src/Aura/Di/ConfigInterface.php
+++ b/src/Aura/Di/ConfigInterface.php
@@ -52,6 +52,8 @@ interface ConfigInterface
      * 
      * Gets a retained ReflectionClass; if not already retained, creates and
      * retains one before returning it.
+     *
+     * @throws Exception\ServiceInvalid In case reflection could not reflect a class
      * 
      * @param string $class The class to reflect on.
      * 

--- a/tests/Aura/Di/ConfigTest.php
+++ b/tests/Aura/Di/ConfigTest.php
@@ -133,4 +133,14 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($clone->getParams(), $this->config->getParams());
         $this->assertNotSame($clone->getSetter(), $this->config->getSetter());
     }
+
+    /**
+     * @expectedException        Aura\Di\Exception\ServiceInvalid
+     * @expectedExceptionMessage Service class No such class is invalid
+     * @expectedExceptionCode    0
+     */
+    public function testExceptionOnGetReflect()
+    {
+        $this->config->getReflect('No such class');
+    }
 }


### PR DESCRIPTION
When creating a new ReflectionClass in Config::getReflect() fails, a ReflectionException is thrown. Config object should fetch it and rethrow as Aura\DI\Exception, thus encapsulating external exceptions.
