### PR TITLE
Adds a type hint option for the type hinting of objects from the container.

### DIFF
--- a/src.php
+++ b/src.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/src/Aura/Di/Exception/ReflectionFailure.php';
 require_once __DIR__ . '/src/Aura/Di/Exception/ServiceNotObject.php';
 require_once __DIR__ . '/src/Aura/Di/Exception/ServiceNotFound.php';
 require_once __DIR__ . '/src/Aura/Di/Exception/SetterMethodNotFound.php';
+require_once __DIR__ . '/src/Aura/Di/Exception/TypeHintFailed.php';
 require_once __DIR__ . '/src/Aura/Di/Factory.php';
 require_once __DIR__ . '/src/Aura/Di/ForgeInterface.php';
 require_once __DIR__ . '/src/Aura/Di/Forge.php';

--- a/src/Aura/Di/Container.php
+++ b/src/Aura/Di/Container.php
@@ -222,19 +222,23 @@ class Container implements ContainerInterface
         return $this;
     }
 
+
     /**
      * 
      * Gets a service object by key, lazy-loading it as needed.
      * 
      * @param string $key The service to get.
+     * @param string $type The expected type by the requester.
      * 
      * @return object
      * 
-     * @throws Exception\ServiceNotFound when the requested service
+     * @throws \Aura\Di\Exception\ServiceNotFound when the requested service
      * does not exist.
+     * @throws \Aura\Di\Exception\TypeHintFailed when the type hint does not
+     * match the provided value.
      * 
      */
-    public function get($key)
+    public function get($key, $type = null)
     {
         // does the definition exist?
         if (! $this->has($key)) {
@@ -252,7 +256,14 @@ class Container implements ContainerInterface
             // retain
             $this->services[$key] = $service;
         }
-
+        
+        // Does it match the type expected by the requester?
+        if ($type) {
+           if (! ($this->services[$key] instanceof $type)) {
+               throw new Exception\TypeHintFailed($key);
+           } 
+        }
+        
         // done
         return $this->services[$key];
     }

--- a/src/Aura/Di/ContainerInterface.php
+++ b/src/Aura/Di/ContainerInterface.php
@@ -74,14 +74,17 @@ interface ContainerInterface
      * Gets a service object by key, lazy-loading it as needed.
      * 
      * @param string $key The service to get.
+     * @param string $type The expected type by the requester.
      * 
      * @return object
      * 
      * @throws \Aura\Di\Exception\ServiceNotFound when the requested service
      * does not exist.
+     * @throws \Aura\Di\Exception\TypeHintFailed when the type hint does not
+     * match the provided value.
      * 
      */
-    public function get($key);
+    public function get($key, $type = null);
 
     /**
      * 

--- a/tests/Aura/Di/ContainerTest.php
+++ b/tests/Aura/Di/ContainerTest.php
@@ -97,6 +97,21 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
     
+    public function testGetWithTypehint() {
+        $this->container->set('foo', new \StdClass);
+        
+        $foo = $this->container->get('foo', '\StdClass');
+        $this->assertTrue($foo instanceof \StdClass);
+    }
+    
+    /**
+     * @expectedException Aura\Di\Exception\TypeHintFailed
+     */
+    public function testGetTypehintFailureException() {
+        $this->container->set('foo', new \StdClass);
+        $this->container->get('foo', 'This\Doesnt\Exist');
+    }
+    
     public function testLazyGet()
     {
         $this->container->set('foo', function() {


### PR DESCRIPTION
Part of Dependency Injection is the ability to type hint for a particular object. Using the DI object makes it possible that a particular key will be set, but not contain the object that the requester expects. This will lead to fatal errors and would be best handled through type hinting the object.

This patch raises an exception when the type hint fails. The type hint is optional, and is evaluated only on the get() method since other methods allow for specifying the object that you want to create/get back.
