### PR TITLE
Explicit inheritance only

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -412,9 +412,9 @@ class Container implements ContainerInterface
         // merge param configs and load lazy objects
         if ($merge_params) {
             $this->mergeParams($params, $merge_params);
-        } else {
-            $this->loadLazyParams($params);
         }
+
+        $this->loadLazyParams($params);
         
         // and create the new instance
         $rclass = $this->getReflection($class);
@@ -467,12 +467,7 @@ class Container implements ContainerInterface
                 // named override
                 $val = $merge_params[$key];
             }
-            
-            // load lazy objects as we go
-            if ($val instanceof LazyInterface) {
-                $val = $val();
-            }
-            
+
             // retain the merged value
             $params[$key] = $val;
             

--- a/src/Container.php
+++ b/src/Container.php
@@ -96,10 +96,7 @@ class Container implements ContainerInterface
     /**
      * 
      * Constructor.
-     * 
-     * @param Config $config A config object for params, setters, reflections,
-     * etc.
-     * 
+     *
      * @param Factory $factory A factory to create support objects.
      * 
      */
@@ -116,7 +113,10 @@ class Container implements ContainerInterface
      * @param string $key The property to retrieve ('params' or 'setter(s)').
      * 
      * @return mixed
-     * 
+     *
+     * @throws Exception\ContainerLocked
+     *
+     * @throws UnexpectedValueException
      */
     public function &__get($key)
     {
@@ -397,6 +397,8 @@ class Container implements ContainerInterface
      * passed to the setter method.
      * 
      * @return object
+     *
+     * @throws Exception\SetterMethodNotFound
      * 
      */
     public function newInstance(
@@ -564,7 +566,7 @@ class Container implements ContainerInterface
      * 
      * @param string $class The class name to return values for.
      * 
-     * @param string $parent The parent unified params.
+     * @param array $parent The parent unified params.
      * 
      * @return array The unified params.
      * 
@@ -609,7 +611,7 @@ class Container implements ContainerInterface
      * 
      * @param string $class The class name to return values for.
      * 
-     * @param string $parent The parent unified setters.
+     * @param array $parent The parent unified setters.
      * 
      * @return array The unified setters.
      * 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -10,8 +10,6 @@
  */
 namespace Aura\Di;
 
-use Aura\Di\Container;
-
 /**
  * 
  * A factory to create support objects for the Container.
@@ -37,7 +35,7 @@ class Factory
      * 
      */
     public function newInstanceFactory(
-        Container $container,
+        ContainerInterface $container,
         $class,
         array $params = array(),
         array $setter = array()
@@ -65,14 +63,14 @@ class Factory
      * 
      * Returns a new LazyGet.
      * 
-     * @param Container $container The service container.
+     * @param ContainerInterface $container The service container.
      * 
      * @param string $service The service to retrieve.
      * 
      * @return LazyGet
      * 
      */
-    public function newLazyGet(Container $container, $service)
+    public function newLazyGet(ContainerInterface $container, $service)
     {
         return new LazyGet($container, $service);
     }
@@ -95,7 +93,7 @@ class Factory
      * 
      * Returns a new LazyNew.
      * 
-     * @param Container $container The service container.
+     * @param ContainerInterface $container The service container.
      * 
      * @param string $class The class to instantiate.
      * 
@@ -107,7 +105,7 @@ class Factory
      * 
      */
     public function newLazyNew(
-        Container $container,
+        ContainerInterface $container,
         $class,
         array $params,
         array $setter

--- a/src/LazyGet.php
+++ b/src/LazyGet.php
@@ -10,8 +10,6 @@
  */
 namespace Aura\Di;
 
-use Aura\Di\Container;
-
 /**
  * 
  * Wraps a callable specifically for the purpose of lazy-loading an object.
@@ -43,14 +41,12 @@ class LazyGet implements LazyInterface
      * 
      * Constructor.
      * 
-     * @param Container $container The service container.
+     * @param ContainerInterface $container The service container.
      * 
      * @param string $service The service to retrieve.
      * 
-     * @return null
-     * 
      */
-    public function __construct(Container $container, $service)
+    public function __construct(ContainerInterface $container, $service)
     {
         $this->container = $container;
         $this->service = $service;

--- a/src/LazyInclude.php
+++ b/src/LazyInclude.php
@@ -33,9 +33,7 @@ class LazyInclude implements LazyInterface
      * Constructor.
      * 
      * @param string $file The file to include.
-     * 
-     * @return null
-     * 
+     *
      */
     public function __construct($file)
     {

--- a/src/LazyNew.php
+++ b/src/LazyNew.php
@@ -10,8 +10,6 @@
  */
 namespace Aura\Di;
 
-use Aura\Di\Container;
-
 /**
  * 
  * Wraps a callable specifically for the purpose of lazy-loading an object.
@@ -61,16 +59,16 @@ class LazyNew implements LazyInterface
      * 
      * Constructor.
      * 
-     * @param Container $container The service container.
+     * @param ContainerInterface $container The service container.
      * 
      * @param string $class The class to instantiate.
      * 
      * @param array $params Params for the instantiation.
      * 
-     * @param array $setter Setters for the instantiation.
+     * @param array $setters Setters for the instantiation.
      * 
      */
-    public function __construct(Container $container, $class, array $params, array $setters)
+    public function __construct(ContainerInterface $container, $class, array $params, array $setters)
     {
         $this->container = $container;
         $this->class = $class;

--- a/src/LazyRequire.php
+++ b/src/LazyRequire.php
@@ -33,9 +33,7 @@ class LazyRequire implements LazyInterface
      * Constructor.
      * 
      * @param string $file The file to require.
-     * 
-     * @return null
-     * 
+     *
      */
     public function __construct($file)
     {

--- a/tests/bench.php
+++ b/tests/bench.php
@@ -19,6 +19,7 @@ class Zim extends Dib {}
 class Gir extends Zim {}
 
 $di = new Container(new Factory);
+$di->params['Foo']['param'] = 'test';
 $k = 10000;
 
 $before = microtime(true);

--- a/tests/src/ContainerTest.php
+++ b/tests/src/ContainerTest.php
@@ -286,7 +286,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         list($actual_params, $actual_setter) = $this->container->getUnified('Aura\Di\MockParentClass');
         $this->assertSame($expect, $actual_params);
     }
-    
+
     /**
      * coverage for the "merged already" portion of the fetch() method
      */
@@ -296,18 +296,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $actual = $this->container->getUnified('Aura\Di\MockParentClass');
         $this->assertSame($expect, $actual);
     }
-    
-    public function testHonorsParentParams()
-    {
-        $expect = array(
-            'foo' => 'bar',
-            'zim' => null,
-        );
-        
-        list($actual_params, $actual_setter) = $this->container->getUnified('Aura\Di\MockChildClass');
-        $this->assertSame($expect, $actual_params);
-    }
-    
+
     public function testHonorsExplicitParams()
     {
         $this->container->params['Aura\Di\MockParentClass'] = array('foo' => 'zim');
@@ -316,23 +305,34 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         list($actual_params, $actual_setter) = $this->container->getUnified('Aura\Di\MockParentClass');
         $this->assertSame($expect, $actual_params);
     }
-    
+
     public function testHonorsExplicitParentParams()
     {
         $this->container->params['Aura\Di\MockParentClass'] = array('foo' => 'dib');
         
         $expect = array(
-            'foo' => 'dib',
-            'zim' => null,
+            'foo' => 'dib'
         );
         
         list($actual_params, $actual_setter) = $this->container->getUnified('Aura\Di\MockChildClass');
+        array_splice($actual_params, 1);
         $this->assertSame($expect, $actual_params);
         
         // for test coverage of the mock class
         $child = new \Aura\Di\MockChildClass('bar', new \Aura\Di\MockOtherClass);
     }
-    
+
+    public function testHonorsExplicitParentParamsOnly()
+    {
+        $expect = array(
+            'foo' => null
+        );
+
+        list($actual_params, $actual_setter) = $this->container->getUnified('Aura\Di\MockChildClass');
+        array_splice($actual_params, 1);
+        $this->assertSame($expect, $actual_params);
+    }
+
     public function testHonorsParentSetter()
     {
         $this->container->setter['Aura\Di\MockParentClass']['setFake'] = 'fake1';


### PR DESCRIPTION
Hi,

As I said in https://groups.google.com/d/msg/auraphp/OBbGxJvZcho/KSip3TAek4gJ
I does not seems normal to inherit of default value of parents.

My real goal is to add automatic resolution of type hinted arguments, it does not seems normal to inherit of that either. So I changed inheritance of constructor params to explicit params only (params defined in the DI).

There are also some other small changes before that (fix docblock and use containerInterface in the factory)

I tried to do atomic commits, so you can pick what you want and see the process i've followed.
