### PR TITLE
docblock corrections

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -25,7 +25,7 @@ class Factory
      * 
      * Returns a new InstanceFactory.
      * 
-     * @param ContainerInterface $container The service container.
+     * @param Container $container The service container.
      * 
      * @param string $class The class to create.
      * 

--- a/src/LazyGet.php
+++ b/src/LazyGet.php
@@ -10,8 +10,6 @@
  */
 namespace Aura\Di;
 
-use Aura\Di\Container;
-
 /**
  * 
  * Wraps a callable specifically for the purpose of lazy-loading an object.

--- a/src/LazyGet.php
+++ b/src/LazyGet.php
@@ -47,8 +47,6 @@ class LazyGet implements LazyInterface
      * 
      * @param string $service The service to retrieve.
      * 
-     * @return null
-     * 
      */
     public function __construct(Container $container, $service)
     {

--- a/src/LazyInclude.php
+++ b/src/LazyInclude.php
@@ -33,9 +33,7 @@ class LazyInclude implements LazyInterface
      * Constructor.
      * 
      * @param string $file The file to include.
-     * 
-     * @return null
-     * 
+     *
      */
     public function __construct($file)
     {

--- a/src/LazyNew.php
+++ b/src/LazyNew.php
@@ -67,7 +67,7 @@ class LazyNew implements LazyInterface
      * 
      * @param array $params Params for the instantiation.
      * 
-     * @param array $setter Setters for the instantiation.
+     * @param array $setters Setters for the instantiation.
      * 
      */
     public function __construct(Container $container, $class, array $params, array $setters)

--- a/src/LazyRequire.php
+++ b/src/LazyRequire.php
@@ -34,8 +34,6 @@ class LazyRequire implements LazyInterface
      * 
      * @param string $file The file to require.
      * 
-     * @return null
-     * 
      */
     public function __construct($file)
     {


### PR DESCRIPTION
A number of docblock corrections correcting type, a spelling error `$letter` -> `$letters`, @return removed on methods that do not return.
