### PR TITLE
Teeny-tiny syntax error fix in the readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ $di->params['Example\Package\ModelFactory'] = array(
     'map' => array(
         'blog' => $di->newFactory('Example\Package\BlogModel'),
         'wiki' => $di->newFactory('Example\Package\WikiModel'),
-    ],
+    ),
 );
 
 // default params for page controllers


### PR DESCRIPTION
This has been bothering me for a while :P I imagine it was simply missed during the move to support PHP 5.3.
