### PR TITLE
Add auto-resolution capability

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -66,12 +66,12 @@ class Container implements ContainerInterface
 
     /**
      *
-     * A reference to the Factory $resolve.
+     * A reference to the Factory $types.
      *
      * @var array
      *
      */
-    protected $resolve;
+    protected $types;
 
     /**
      *
@@ -118,7 +118,7 @@ class Container implements ContainerInterface
         $this->params =& $this->factory->params;
         $this->setter =& $this->factory->setter;
         $this->values =& $this->factory->values;
-        $this->resolve =& $this->factory->resolve;
+        $this->types =& $this->factory->types;
     }
 
     /**
@@ -153,8 +153,8 @@ class Container implements ContainerInterface
             return $this->values;
         }
 
-        if ($key == 'resolve') {
-            return $this->resolve;
+        if ($key == 'type' || $key == 'types') {
+            return $this->types;
         }
 
         throw new UnexpectedValueException($key);

--- a/src/Container.php
+++ b/src/Container.php
@@ -57,6 +57,15 @@ class Container implements ContainerInterface
 
     /**
      *
+     * A reference to the Factory $resolve.
+     *
+     * @var array
+     *
+     */
+    protected $resolve;
+
+    /**
+     *
      * Retains named service definitions.
      *
      * @var array
@@ -99,6 +108,7 @@ class Container implements ContainerInterface
         $this->factory = $factory;
         $this->params =& $this->factory->params;
         $this->setter =& $this->factory->setter;
+        $this->resolve =& $this->factory->resolve;
     }
 
     /**
@@ -121,12 +131,16 @@ class Container implements ContainerInterface
             throw new Exception\ContainerLocked;
         }
 
-        if ($key == 'params') {
+        if ($key == 'param' || $key == 'params') {
             return $this->params;
         }
 
         if ($key == 'setter' || $key == 'setters') {
             return $this->setter;
+        }
+
+        if ($key == 'resolve') {
+            return $this->resolve;
         }
 
         throw new UnexpectedValueException($key);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -410,11 +410,22 @@ class Factory
         }
 
         if ($rparam->isDefaultValueAvailable()) {
-            // use the reflected value from the constructor
+            // use the default value
             return $rparam->getDefaultValue();
         }
 
-        // no recognized value, return a null placeholder
+        if ($rparam->isArray()) {
+            // use an empty array
+            return array();
+        }
+
+        $typehint = $rparam->getClass();
+        if ($typehint && $typehint->isInstantiable()) {
+            // use a lazy-new-instance of the typehinted class
+            return $this->newLazyNew($typehint->name);
+        }
+
+        // use a null as a placeholder
         return null;
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -385,24 +385,37 @@ class Factory
         $rparams = $rctor->getParameters();
         foreach ($rparams as $rparam) {
             $name = $rparam->name;
-            $explicit = isset($this->params[$class][$name]);
-            if ($explicit) {
-                // use the explicit value for this class
-                $unified[$name] = $this->params[$class][$name];
-            } elseif (isset($parent[$name])) {
-                // use the implicit value from the parent class
-                $unified[$name] = $parent[$name];
-            } elseif ($rparam->isDefaultValueAvailable()) {
-                // use the reflected value from the constructor
-                $unified[$name] = $rparam->getDefaultValue();
-            } else {
-                // no value, use a null placeholder
-                $unified[$name] = null;
-            }
+            $unified[$name] = $this->getUnifiedParam(
+                $rparam,
+                $class,
+                $parent,
+                $name
+            );
         }
 
         // done
         return $unified;
+    }
+
+    protected function getUnifiedParam($rparam, $class, $parent, $name)
+    {
+        if (isset($this->params[$class][$name])) {
+            // use the explicit value for this class
+            return $this->params[$class][$name];
+        }
+
+        if (isset($parent[$name])) {
+            // use the implicit value from the parent class
+            return $parent[$name];
+        }
+
+        if ($rparam->isDefaultValueAvailable()) {
+            // use the reflected value from the constructor
+            return $rparam->getDefaultValue();
+        }
+
+        // no recognized value, return a null placeholder
+        return null;
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -82,7 +82,7 @@ class Factory
      * @var array
      *
      */
-    protected $revolve = array();
+    protected $resolve = array();
 
     /**
      *

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -66,7 +66,16 @@ class Factory
 
     /**
      *
-     * Returns a reference to the $params array.
+     * Auto-resolve these typehints to these values.
+     *
+     * @var array
+     *
+     */
+    protected $revolve = array();
+
+    /**
+     *
+     * Returns a reference to various property arrays.
      *
      * @return array
      *
@@ -419,10 +428,15 @@ class Factory
             return array();
         }
 
-        $typehint = $rparam->getClass();
-        if ($typehint && $typehint->isInstantiable()) {
+        $rtype = $rparam->getClass();
+        if ($rtype && isset($this->resolve[$rtype->name])) {
+            // use an explict auto-resolution
+            return $this->resolve[$rtype->name];
+        }
+
+        if ($rtype && $rtype->isInstantiable()) {
             // use a lazy-new-instance of the typehinted class
-            return $this->newLazyNew($typehint->name);
+            return $this->newLazyNew($rtype->name);
         }
 
         // use a null as a placeholder

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -82,7 +82,7 @@ class Factory
      * @var array
      *
      */
-    protected $resolve = array();
+    protected $types = array();
 
     /**
      *
@@ -445,9 +445,9 @@ class Factory
         }
 
         $rtype = $rparam->getClass();
-        if ($rtype && isset($this->resolve[$rtype->name])) {
+        if ($rtype && isset($this->types[$rtype->name])) {
             // use an explict auto-resolution
-            return $this->resolve[$rtype->name];
+            return $this->types[$rtype->name];
         }
 
         if ($rtype && $rtype->isInstantiable()) {

--- a/tests/src/ContainerTest.php
+++ b/tests/src/ContainerTest.php
@@ -326,7 +326,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testResolve()
     {
-        $this->container->resolve['Aura\Di\FakeParentClass'] = $this->container->lazyNew('Aura\Di\FakeChildClass');
+        $this->container->types['Aura\Di\FakeParentClass'] = $this->container->lazyNew('Aura\Di\FakeChildClass');
         $actual = $this->container->newInstance('Aura\Di\FakeResolveClass');
         $this->assertInstanceOf('Aura\Di\FakeResolveClass', $actual);
         $this->assertInstanceOf('Aura\Di\FakeChildClass', $actual->fake);

--- a/tests/src/ContainerTest.php
+++ b/tests/src/ContainerTest.php
@@ -316,4 +316,11 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('keepme', $actual->getFoo());
     }
 
+    public function testResolve()
+    {
+        $this->container->resolve['Aura\Di\FakeParentClass'] = $this->container->lazyNew('Aura\Di\FakeChildClass');
+        $actual = $this->container->newInstance('Aura\Di\FakeResolveClass');
+        $this->assertInstanceOf('Aura\Di\FakeResolveClass', $actual);
+        $this->assertInstanceOf('Aura\Di\FakeChildClass', $actual->fake);
+    }
 }

--- a/tests/src/FactoryTest.php
+++ b/tests/src/FactoryTest.php
@@ -137,6 +137,13 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Aura\Di\FakeOtherClass', $actual);
     }
 
+    public function testAutoResolveExplicit()
+    {
+        $this->factory->resolve['Aura\Di\FakeParentClass'] = $this->factory->newLazyNew('Aura\Di\FakeChildClass');
+        $object = $this->factory->newInstance('Aura\Di\FakeResolveClass');
+        $this->assertInstanceOf('Aura\Di\FakeChildClass', $object->fake);
+    }
+
     public function testAutoResolveNewInstance()
     {
         $object = $this->factory->newInstance('Aura\Di\FakeChildClass');

--- a/tests/src/FactoryTest.php
+++ b/tests/src/FactoryTest.php
@@ -33,7 +33,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         );
 
         list($actual_params, $actual_setter) = $this->factory->getUnified('Aura\Di\FakeChildClass');
-        $this->assertSame($expect, $actual_params);
+        $this->assertSame($expect['foo'], $actual_params['foo']);
     }
 
     public function testHonorsExplicitParams()
@@ -55,7 +55,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         );
 
         list($actual_params, $actual_setter) = $this->factory->getUnified('Aura\Di\FakeChildClass');
-        $this->assertSame($expect, $actual_params);
+        $this->assertSame($expect['foo'], $actual_params['foo']);
 
         // for test coverage of the mock class
         $child = new \Aura\Di\FakeChildClass('bar', new \Aura\Di\FakeOtherClass);
@@ -135,5 +135,20 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $object = $this->factory->newInstance('Aura\Di\FakeParentClass');
         $actual = $object->getFoo();
         $this->assertInstanceOf('Aura\Di\FakeOtherClass', $actual);
+    }
+
+    public function testAutoResolveNewInstance()
+    {
+        $object = $this->factory->newInstance('Aura\Di\FakeChildClass');
+        $this->assertSame('bar', $object->getFoo());
+        $this->assertNull($object->getFake());
+        $this->assertInstanceOf('Aura\Di\FakeOtherClass', $object->getZim());
+    }
+
+    public function testAutoResolveArrayAndNull()
+    {
+        $object = $this->factory->newInstance('Aura\Di\FakeParamsClass');
+        $this->assertSame(array(), $object->array);
+        $this->assertNull($object->empty);
     }
 }

--- a/tests/src/FactoryTest.php
+++ b/tests/src/FactoryTest.php
@@ -145,7 +145,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoResolveExplicit()
     {
-        $this->factory->resolve['Aura\Di\FakeParentClass'] = $this->factory->newLazyNew('Aura\Di\FakeChildClass');
+        $this->factory->types['Aura\Di\FakeParentClass'] = $this->factory->newLazyNew('Aura\Di\FakeChildClass');
         $object = $this->factory->newInstance('Aura\Di\FakeResolveClass');
         $this->assertInstanceOf('Aura\Di\FakeChildClass', $object->fake);
     }

--- a/tests/src/FactoryTest.php
+++ b/tests/src/FactoryTest.php
@@ -33,7 +33,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         );
 
         list($actual_params, $actual_setter) = $this->factory->getUnified('Aura\Di\FakeChildClass');
-        $this->assertSame($expect['foo'], $actual_params['foo']);
+        $this->assertSame($expect, $actual_params);
     }
 
     public function testHonorsExplicitParams()
@@ -55,7 +55,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         );
 
         list($actual_params, $actual_setter) = $this->factory->getUnified('Aura\Di\FakeChildClass');
-        $this->assertSame($expect['foo'], $actual_params['foo']);
+        $this->assertSame($expect, $actual_params);
 
         // for test coverage of the mock class
         $child = new \Aura\Di\FakeChildClass('bar', new \Aura\Di\FakeOtherClass);
@@ -137,19 +137,17 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Aura\Di\FakeOtherClass', $actual);
     }
 
+    public function testAutoResolveImplicit()
+    {
+        $object = $this->factory->newInstance('Aura\Di\FakeResolveClass');
+        $this->assertInstanceOf('Aura\Di\FakeParentClass', $object->fake);
+    }
+
     public function testAutoResolveExplicit()
     {
         $this->factory->resolve['Aura\Di\FakeParentClass'] = $this->factory->newLazyNew('Aura\Di\FakeChildClass');
         $object = $this->factory->newInstance('Aura\Di\FakeResolveClass');
         $this->assertInstanceOf('Aura\Di\FakeChildClass', $object->fake);
-    }
-
-    public function testAutoResolveNewInstance()
-    {
-        $object = $this->factory->newInstance('Aura\Di\FakeChildClass');
-        $this->assertSame('bar', $object->getFoo());
-        $this->assertNull($object->getFake());
-        $this->assertInstanceOf('Aura\Di\FakeOtherClass', $object->getZim());
     }
 
     public function testAutoResolveArrayAndNull()

--- a/tests/src/FakeChildClass.php
+++ b/tests/src/FakeChildClass.php
@@ -6,7 +6,7 @@ class FakeChildClass extends FakeParentClass
 
     protected $fake;
 
-    public function __construct($foo, FakeOtherClass $zim)
+    public function __construct($foo, $zim = null)
     {
         parent::__construct($foo);
         $this->zim = $zim;

--- a/tests/src/FakeParamsClass.php
+++ b/tests/src/FakeParamsClass.php
@@ -1,0 +1,13 @@
+<?php
+namespace Aura\Di;
+
+class FakeParamsClass
+{
+    public $array;
+    public $empty = 'not null';
+    public function __construct(array $array, $empty)
+    {
+        $this->array = $array;
+        $this->empty = null;
+    }
+}

--- a/tests/src/FakeResolveClass.php
+++ b/tests/src/FakeResolveClass.php
@@ -1,0 +1,11 @@
+<?php
+namespace Aura\Di;
+
+class FakeResolveClass
+{
+    public $fake;
+    public function __construct(FakeParentClass $fake)
+    {
+        $this->fake = $fake;
+    }
+}


### PR DESCRIPTION
This allows type hinted constructor params, that do not have explicit DI values, to receive new instances of their type hinted classes. It also allows explicit auto-resolution of type hints to a specific class or service. Incidentally, params type hinted to `array` will receive empty arrays when no explicit value is passed.
