### PR TITLE
Moving the autoResolve settings up in the function.

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -61,6 +61,7 @@ class ContainerBuilder
         $auto_resolve = self::ENABLE_AUTO_RESOLVE
     ) {
         $di = new Container(new Factory);
+        $di->setAutoResolve($auto_resolve);
 
         foreach ($services as $key => $val) {
             $di->set($key, $val);
@@ -73,7 +74,6 @@ class ContainerBuilder
             $configs[] = $config;
         }
 
-        $di->setAutoResolve($auto_resolve);
         $di->lock();
 
         foreach ($configs as $config) {


### PR DESCRIPTION
This moves Container::setAutoResolve() higher in the order of functions.

Why would we want to make this change? If a user turns off autoResolve, we should not let the configuration run with autoresolve on, and then turn it off. This creates unexpected behavior, especially if they create a new instance during the loading of the configuration. 

For example, I pass an array of objects to another object. Those objects are not supposed to be callable, but Container::lazyNew() returns a callable when placed in an array. In order to avoid that, I use Container::newInstance(). A configuration error meant that I was trying to instantiate PDO before configuring it, but with setAutoResolve so low in the actions to be performed, PDO was being automatically configured instead of getting a MissingParam exception as I expected. This made debugging very difficult.
