### PR TITLE
Add missing docblock properties types and values

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -26,6 +26,8 @@ use UnexpectedValueException;
  * @property-read array $setters A reference to the Factory $setter.
  * 
  * @property-read array $types A reference to the Factory $types.
+ * 
+ * @property-read array $values A reference to the Factory $values.
  *
  */
 class Container implements ContainerInterface

--- a/src/Container.php
+++ b/src/Container.php
@@ -24,6 +24,8 @@ use UnexpectedValueException;
  * @property-read array $setter A reference to the Factory $setter.
  *
  * @property-read array $setters A reference to the Factory $setter.
+ * 
+ * @property-read array $types A reference to the Factory $types.
  *
  */
 class Container implements ContainerInterface


### PR DESCRIPTION
Added the properties `$di->container->types` and `$di->container->values` to the docblock of the container class. They were both missing.
