### PR TITLE
Patch/doc error

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ class ExampleWithParams
 
 If we were to try to set a service using `$di->lazyNew('ExampleWithParams')`, the instantiation would fail. The `$foo` param is required, and the _Container_ does not know what to use for that value.
 
-To remedy this, we tell the _Container_ what values to use for each _ExampleWithParams_ constructor parameter by name using the `$di->params` array:
+To remedy this, we tell the _Container_ what values to use for each _ExampleWithParams_ constructor parameter by name using the `$di->params` array:def
 
 ```php
 <?php
@@ -211,7 +211,7 @@ For example, look at the following class; it has a parameter with a default valu
 <?php
 class ExampleForAutoResolution
 {
-    public function __construct($foo = 'bar', array $baz, Example $dib)
+    public function __construct(array $baz, Example $dib, $foo = 'bar')
     {
         // ...
     }
@@ -223,9 +223,9 @@ For each relevant `$di->params['ExampleForAutoResolution']` element that is miss
 
 ```php
 <?php
-$di->params['ExampleForAutoResolution']['foo'] = 'bar';
 $di->params['ExampleForAutoResolution']['baz'] = array();
 $di->params['ExampleForAutoResolution']['dib'] = $di->lazyNew('Example');
+$di->params['ExampleForAutoResolution']['foo'] = 'bar';
 ?>
 ```
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ class ExampleWithParams
 
 If we were to try to set a service using `$di->lazyNew('ExampleWithParams')`, the instantiation would fail. The `$foo` param is required, and the _Container_ does not know what to use for that value.
 
-To remedy this, we tell the _Container_ what values to use for each _ExampleWithParams_ constructor parameter by name using the `$di->params` array:def
+To remedy this, we tell the _Container_ what values to use for each _ExampleWithParams_ constructor parameter by name using the `$di->params` array:
 
 ```php
 <?php


### PR DESCRIPTION
I've seen a typo in the documentation.

When you explain the behavior of the container with a constructor with default values in some of the arguments, you set the default value in the first argument, which is not valid in PHP.
I've changed it to the last argument.
