### PR TITLE
Adding support for container-interop's delegate dependency lookup concept

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,10 @@
         "php": ">=5.6.0",
         "container-interop/container-interop": "~1.0"
     },
+    "require-dev": {
+        "mouf/picotainer": "~1.0",
+        "acclimate/container": "~1.0"
+    },
     "autoload": {
         "psr-4": {
             "Aura\\Di\\": "src/"

--- a/src/Container.php
+++ b/src/Container.php
@@ -41,6 +41,16 @@ class Container implements ContainerInterface
 
     /**
      *
+     * A container that will be used instead of the main container
+     * to fetch dependencies.
+     *
+     * @var ContainerInterface
+     *
+     */
+    protected $delegateLookupContainer;
+
+    /**
+     *
      * A Resolver obtained from the InjectionFactory.
      *
      * @var Resolver\Resolver
@@ -86,12 +96,17 @@ class Container implements ContainerInterface
      *
      * @param InjectionFactory $injectionFactory A factory to create objects and
      * values for injection.
+     * @param ContainerInterface $delegateLookupContainer An optional container
+     * that will be used to fetch dependencies (i.e. lazy gets)
      *
      */
-    public function __construct(InjectionFactory $injectionFactory)
-    {
+    public function __construct(
+        InjectionFactory $injectionFactory,
+        ContainerInterface $delegateLookupContainer = null
+    ) {
         $this->injectionFactory = $injectionFactory;
         $this->resolver = $this->injectionFactory->getResolver();
+        $this->delegateLookupContainer = $delegateLookupContainer ?: $this;
     }
 
     /**
@@ -279,7 +294,7 @@ class Container implements ContainerInterface
      */
     public function lazyGet($service)
     {
-        return $this->injectionFactory->newLazyGet($this, $service);
+        return $this->injectionFactory->newLazyGet($this->delegateLookupContainer, $service);
     }
 
     /**

--- a/src/Injection/InjectionFactory.php
+++ b/src/Injection/InjectionFactory.php
@@ -10,6 +10,7 @@ namespace Aura\Di\Injection;
 
 use Aura\Di\Container;
 use Aura\Di\Resolver\Resolver;
+use Interop\Container\ContainerInterface;
 use ReflectionException;
 
 /**
@@ -121,14 +122,14 @@ class InjectionFactory
      *
      * Returns a new LazyGet.
      *
-     * @param Container $container The service container.
+     * @param ContainerInterface $container The service container.
      *
      * @param string $service The service to retrieve.
      *
      * @return LazyGet
      *
      */
-    public function newLazyGet(Container $container, $service)
+    public function newLazyGet(ContainerInterface $container, $service)
     {
         return new LazyGet($container, $service);
     }

--- a/src/Injection/LazyGet.php
+++ b/src/Injection/LazyGet.php
@@ -9,6 +9,7 @@
 namespace Aura\Di\Injection;
 
 use Aura\Di\Container;
+use Interop\Container\ContainerInterface;
 
 /**
  *
@@ -41,12 +42,12 @@ class LazyGet implements LazyInterface
      *
      * Constructor.
      *
-     * @param Container $container The service container.
+     * @param ContainerInterface $container The service container.
      *
      * @param string $service The service to retrieve.
      *
      */
-    public function __construct(Container $container, $service)
+    public function __construct(ContainerInterface $container, $service)
     {
         $this->container = $container;
         $this->service = $service;

--- a/src/Injection/LazyGet.php
+++ b/src/Injection/LazyGet.php
@@ -24,7 +24,7 @@ class LazyGet implements LazyInterface
      *
      * The service container.
      *
-     * @var Container
+     * @var ContainerInterface
      *
      */
     protected $container;

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -398,7 +398,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $compositeContainer->addContainer($auraContainer);
 
         $service1 = $compositeContainer->get('service1');
-        //$service = $auraContainer->get('Aura\Di\Fake\FakeParentClass');
 
         $this->assertEquals('bar', $service1->getFoo()->array[0]->foo);
     }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,6 +1,13 @@
 <?php
 namespace Aura\Di;
 
+use Acclimate\Container\CompositeContainer;
+use Aura\Di\Fake\FakeParamsClass;
+use Aura\Di\Injection\InjectionFactory;
+use Aura\Di\Resolver\Reflector;
+use Aura\Di\Resolver\Resolver;
+use Mouf\Picotainer\Picotainer;
+
 class ContainerTest extends \PHPUnit_Framework_TestCase
 {
     protected $container;
@@ -338,5 +345,61 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->container->params['Aura\Di\Fake\FakeResolveClass']['fake'] = $this->container->lazyNew('Aura\Di\Fake\FakeParentClass');
         $actual = $this->container->newInstance('Aura\Di\Fake\FakeResolveClass');
         $this->assertInstanceOf('Aura\Di\Fake\FakeResolveClass', $actual);
+    }
+
+    public function testDependencyLookupSimple() {
+
+        $picotainer = new Picotainer([
+            "foo" => function($container) {
+                $obj = new \stdClass();
+                $obj->foo = "bar";
+                return $obj;
+            }
+        ]);
+
+        $auraContainer = new Container(new InjectionFactory(new Resolver(new Reflector())), $picotainer);
+
+        $lazy = $auraContainer->lazyGet('foo');
+
+        $this->assertInstanceOf('Aura\Di\Injection\LazyGet', $lazy);
+
+        $foo = $lazy();
+
+        $this->assertInstanceOf('stdClass', $foo);
+        $this->assertEquals('bar', $foo->foo);
+    }
+
+    public function testDependencyLookup()
+    {
+        // A composite container with 2 containers: Aura and Picotainer.
+        // 'service1' (in Aura) references
+        // 'service2' (in Picotainer) that references
+        // 'service3' (in Aura again)
+        $compositeContainer = new CompositeContainer();
+        $auraContainer = new Container(new InjectionFactory(new Resolver(new Reflector())), $compositeContainer);
+        $auraContainer->params['Aura\Di\Fake\FakeParentClass']['foo'] = $auraContainer->lazyGet('service2');
+
+        // Let's declare service 1
+        $auraContainer->set('service1', $auraContainer->lazyNew('Aura\Di\Fake\FakeParentClass'));
+
+        // Let's declare service 3
+        $obj = new \stdClass();
+        $obj->foo = "bar";
+        $auraContainer->set('service3', $obj);
+
+        $picotainer = new Picotainer([
+            // Let's declare service 2
+            "service2" => function($container) {
+                return new FakeParamsClass([$container->get('service3')], null);
+            },
+        ], $compositeContainer);
+
+        $compositeContainer->addContainer($picotainer);
+        $compositeContainer->addContainer($auraContainer);
+
+        $service1 = $compositeContainer->get('service1');
+        //$service = $auraContainer->get('Aura\Di\Fake\FakeParentClass');
+
+        $this->assertEquals('bar', $service1->getFoo()->array[0]->foo);
     }
 }


### PR DESCRIPTION
Hi,

I've seen that Paul added support for ContainerInterop's ContainerInterface in the Aura.DI v3. This is great news!
This pull request is an attempt to add support for the ["delegate lookup" feature](https://github.com/container-interop/container-interop/blob/master/docs/Delegate-lookup.md) ([meta](https://github.com/container-interop/container-interop/blob/master/docs/Delegate-lookup-meta.md)) defined in container-interop.

The purpose of this feature is to let users work with several containers that can share entries (Aura.DI can refer to entries in another container using the `lazyGet` method, even if the entry is not in Aura.DI.

All in all, the changes seemed quite easy to introduce in Aura.DI, you'll modified very few lines of code. Still, let me know if you think I broke things (I read the code for Aura.DI for the first time this morning). 

The most difficult thing was to write unit tests.
I tried to conform to the "guidelines for contributing" to the best of my abilities. I added 2 dependencies in _composer.json_ but these are `require-dev` dependencies for the unit tests. Since the point of the "delegate lookup" feature is to have containers talking together, I think it makes senses to add another container in the unit tests and have Aura and the other container talk together. Let me know if this is an issue.
