### PR TITLE
add option `throws_on_auto_resolve_failed` and setters to Container and Factory

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -214,6 +214,25 @@ class Container implements ContainerInterface
 
     /**
      *
+     * Enables and disables throws error on auto-resolution failed.
+     *
+     * @param bool $throws_on_auto_resolve_failed True to enable, false to disable.
+     *
+     * @return null
+     *
+     * @throws Exception\ContainerLocked
+     */
+    public function setThrowsOnAutoResolveFailed($throws_on_auto_resolve_failed)
+    {
+        if ($this->isLocked()){
+            throw new Exception\ContainerLocked;
+        }
+
+        $this->factory->setThrowsOnAutoResolveFailed($throws_on_auto_resolve_failed);
+    }
+
+    /**
+     *
      * Does a particular service definition exist?
      *
      * @param string $service The service key to look up.

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -37,6 +37,24 @@ class ContainerBuilder
 
     /**
      *
+     * Enable throws error on auto-resolution failed.
+     *
+     * @const true
+     *
+     */
+    const ENABLE_THROWS_ON_AUTO_RESOLVE_FAILED = true;
+
+    /**
+     *
+     * Enable throws error on auto-resolution failed.
+     *
+     * @const false
+     *
+     */
+    const DISABLE_THROWS_ON_AUTO_RESOLVE_FAILED = false;
+
+    /**
+     *
      * Creates a new DI container, adds pre-existing service objects, applies
      * Config classes to define() services, locks the container, and applies
      * the Config instances to modify() services.
@@ -50,16 +68,21 @@ class ContainerBuilder
      * @param bool $auto_resolve Enable or disable auto-resolve after the
      * define() step?
      *
+     * @param bool $throws_on_auto_resolve_failed Enables or disables throws
+     * error on auto-resolution failed.
+     *
      * @return Container
      *
      */
     public function newInstance(
         array $services = array(),
         array $config_classes = array(),
-        $auto_resolve = self::ENABLE_AUTO_RESOLVE
+        $auto_resolve = self::ENABLE_AUTO_RESOLVE,
+        $throws_on_auto_resolve_failed = self::DISABLE_THROWS_ON_AUTO_RESOLVE_FAILED
     ) {
         $di = new Container(new Factory);
         $di->setAutoResolve($auto_resolve);
+        $di->setThrowsOnAutoResolveFailed($throws_on_auto_resolve_failed);
 
         foreach ($services as $key => $val) {
             $di->set($key, $val);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -81,6 +81,13 @@ class Factory
     protected $auto_resolve = true;
 
     /**
+     * Throws 'MissingParam' on auto-resolve failed.
+     *
+     * @var bool
+     */
+    protected $throws_on_auto_resolve_failed = false;
+
+    /**
      *
      * Auto-resolve these typehints to these values.
      *
@@ -115,6 +122,19 @@ class Factory
     public function setAutoResolve($auto_resolve)
     {
         $this->auto_resolve = (bool) $auto_resolve;
+    }
+
+    /**
+     * Enables and disables throws error on auto-resolution failed.
+     *
+     * @param bool $throws_on_auto_resolve_failed True to enable, false to disable.
+     *
+     * @return null
+     *
+     */
+    public function setThrowsOnAutoResolveFailed($throws_on_auto_resolve_failed)
+    {
+        $this->throws_on_auto_resolve_failed = (bool) $throws_on_auto_resolve_failed;
     }
 
     /**
@@ -272,7 +292,7 @@ class Factory
         }
 
         // are there missing params? don't worry about it with auto-resolve.
-        if (! $this->auto_resolve) {
+        if (! $this->auto_resolve || $this->throws_on_auto_resolve_failed) {
             foreach ($params as $param) {
                 if ($param instanceof MissingParam) {
                     throw new Exception\MissingParam(
@@ -542,6 +562,11 @@ class Factory
         if ($rtype && $rtype->isInstantiable()) {
             // use a lazy-new-instance of the typehinted class
             return $this->newLazyNew($rtype->name);
+        }
+
+        if ( $this->throws_on_auto_resolve_failed ) {
+            // throws error on failed
+            return new MissingParam($name);
         }
 
         // use a null as a placeholder

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -192,4 +192,14 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         );
         $this->factory->newInstance('Aura\Di\FakeResolveClass');
     }
+
+    public function testAutoResolveFailed()
+    {
+        $this->factory->setThrowsOnAutoResolveFailed(true);
+        $this->setExpectedException(
+            'Aura\Di\Exception\MissingParam',
+            'Aura\Di\FakeParamsClass::$empty'
+        );
+        $this->factory->newInstance('Aura\Di\FakeParamsClass');
+    }
 }


### PR DESCRIPTION
I love auto-resolve constructor arguments with type hinted.
But a argument which non-TypeHinted will be `null` makes debug difficult.

``` php
//define classes
class Foo {
    public function __construct(Bar $bar, $val1, $val2) {}
}
class Bar {}
//setup di params
$di->params['Foo'] = ['val1' => 'defaultValue'];

//---try newInstance---

// expect usage: $foo = $di->newInstance('Foo', ['val2' => 'VALUE2']);
// but calls something like this, I forgot pass val2.
$foo = $di->newInstance('Foo');
 //(maybe:) $bar is new Bar(), $val1 is 'defaultValue', $val2 is null
```

This example throws nothing, so I can't catch my mistake!
I want to catch my mistake.

---

Sorry I am not good in English. Thank you for read.
