### PR TITLE
Add ability to track processed configs

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -91,6 +91,15 @@ class Container implements ContainerInterface
     protected $locked = false;
 
     /**
+     * An array representing the class names of ContainerConfig objects which
+     * have been processed
+     *
+     * @var array
+     * @access protected
+     */
+    protected $configured = [];
+
+    /**
      *
      * Constructor.
      *
@@ -256,6 +265,35 @@ class Container implements ContainerInterface
 
         $this->instances[$service] = $this->getServiceInstance($service);
         return $this->instances[$service];
+    }
+
+    /**
+     * Register a ContainerConfig as processed
+     *
+     * @param string $name the name of the class to registered as processed
+     *
+     * @return $this
+     *
+     * @access public
+     */
+    public function addConfigured($name)
+    {
+        $this->configured[] = $name;
+        return $this;
+    }
+
+    /**
+     * Has the named configuration been processed?
+     *
+     * @param string $name the name of the class to check
+     *
+     * @return bool
+     *
+     * @access public
+     */
+    public function hasConfigured($name)
+    {
+        return in_array($name, $this->configured);
     }
 
     /**

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -88,6 +88,7 @@ class ContainerBuilder
         foreach ($configClasses as $configClass) {
             $config = $di->newInstance($configClass);
             $config->define($di);
+            $di->addConfigured($configClass);
             $configs[] = $config;
         }
 

--- a/tests/ContainerBuilderTest.php
+++ b/tests/ContainerBuilderTest.php
@@ -29,6 +29,10 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $expect = 'gir';
         $actual = $di->get('project_service');
         $this->assertSame($expect, $actual->baz);
+
+        $this->assertTrue($di->hasConfigured('Aura\Di\Fake\FakeLibraryConfig'));
+        $this->assertTrue($di->hasConfigured('Aura\Di\Fake\FakeProjectConfig'));
+        $this->assertFalse($di->hasConfigured('foo'));
     }
 
     public function testSerializeAndUnserialize()

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -60,6 +60,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($actual, $again);
     }
 
+    public function testTrackConfigured()
+    {
+        $this->assertFalse($this->container->hasConfigured('foo'));
+        $this->container->addConfigured('foo');
+        $this->assertTrue($this->container->hasConfigured('foo'));
+        $this->assertFalse($this->container->hasConfigured('bar'));
+    }
+
     public function testInitInvalidService()
     {
         $this->setExpectedException('Aura\Di\Exception\ServiceNotObject');


### PR DESCRIPTION
> - Add Container::addConfigured() and Container::hasConfigured()
>   to allow checking if a ConfigContainer has been processed.
> - Implement this functionality in the ContainerBuilder.
> - Add tests for said function

Should there be some way to "track if a 'component' has been configured" when
using the builder?
Something like `$di->hasConfigured('My\Package')` ?

Here's a scenario.
- `Component` provides some basic function.
- `Foo` requires `Component`
- `Bar` requires `Component`
- `Project` requires both `Foo` and `Bar`

My impulse is to allow the delegation of `Component` configuration to `Foo` and
`Bar`, rather than require the consumer `Project` to know it needs
`Component\Config` in addition to `Foo\Config` and `Bar\Config`. However, the
separate `Foo` and `Bar` packages have only less than semantic means of knowing
if `Component` has already been configured, and as such, would be wasting their
time instantiating and processing the gratuitous config a second time.

I would think maybe the ability to do as follows would be useful:

``` php
namespace Component;

class Config extends ContainerConfig
{
    public function define(Contianer $di)
    {
        $di->set('component_service', $di->lazyNew('Component\Service'));
        // ... other stuff
    }
}
```

``` php
// In both Foo and Bar configuration would appear something like the following
// namespace Foo;
// namespace Bar;

class Config extends ContainerConfig
{
    protected $depends = [
        'Component\Config'
    ];

    protected $configs = [];

    public function define(Contianer $di)
    {
        foreach ($this->depends as $configClass) {
            if (! $di->hasConfigured($configClass)) { // check if configured
                $config = $di->newInstance($configClass);
                $config->define($di);
                $di->configured($configClass); // note config has been done
                $this->configs[] = $config;
            }
        }
        // ... other stuff
    }

    public function modify(Container $di)
    {
        foreach ($this->configs as $config) {
            $config->modify($di);
        }
        // other stuff
    }
}
```

``` php
namespace Project;

$di = $container_builder->newConfiguredInstance([
    'Foo\Config',
    'Bar\Config'
    // Don't need to add Component\Config here
    // Also, it will only be instantiated and processed once
]);

```

Currently, one _could_ check if a `service` or `params` has been set, or something
like that. eg:

``` php
class Config extends ContainerConfig
{
    protected $depends = [
        'component_service' => 'Component\Config'
    ];

    protected $configs = [];

    public function define(Contianer $di)
    {
        foreach ($this->depends as $provided => $configClass) {
            if (! $di->has($provided)) { // check for service
            // or maybe (isset($di->params['Component\Service']))
                $config = $di->newInstance($configClass);
                $config->define($di);
                $this->configs[] = $config;
            }
        }
        // ... other stuff
    }
}
```

I also considered storing the class names in the `values` array somehow, but all
this seems off to me. I feel like what I want to know is "has the package been
configured", not just if some particular service or param has been set and using
values just seems abusive. 

Am I off here? Should I not want to know that? Am I just in dependency hell
already, if I feel like I want to know that? Does it not really matter because
it's probably not that expensive to reconfigure the component anyway?

I was going to hold off on a PR until I was sure this made sense, or heard input,
but it seemed simple enough to implement, so here it is. Note this doesn't
**stop** you from processing the config twice if you want to by adding a check
in the builder or anything. It just provides the ability to check if you so
choose.
