### PR TITLE
Allow for mutable virtual properties without IDE errors

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -17,15 +17,15 @@ use UnexpectedValueException;
  *
  * @package Aura.Di
  *
- * @property-read array $params A reference to the Factory $params.
+ * @property array $params A reference to the Factory $params.
  *
- * @property-read array $setter A reference to the Factory $setter.
+ * @property array $setter A reference to the Factory $setter.
  *
- * @property-read array $setters A reference to the Factory $setter.
+ * @property array $setters A reference to the Factory $setter.
  *
- * @property-read array $types A reference to the Factory $types.
+ * @property array $types A reference to the Factory $types.
  *
- * @property-read array $values A reference to the Factory $values.
+ * @property array $values A reference to the Factory $values.
  *
  */
 class Container implements ContainerInterface


### PR DESCRIPTION
Changed @property-read to @property so they will
still be auto-completed, but won't complain if you
try to modify the values via magic methods.

Addresses the issue #91 concern for 2.x.

Without this patch:

![image](https://cloud.githubusercontent.com/assets/775393/9835466/36ddda08-59aa-11e5-93cd-82921a8ac8a7.png)

Note the squiggly red lines.

With the patch:

![image](https://cloud.githubusercontent.com/assets/775393/9835470/5f2a3f42-59aa-11e5-999b-96a7d67ff3cc.png)
