### PR TITLE
3.x fix for @property-read "syntax error"

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -19,13 +19,13 @@ use Interop\Container\ContainerInterface;
  *
  * @package Aura.Di
  *
- * @property-read array $params A reference to the Resolver $params.
+ * @property array $params A reference to the Resolver $params.
  *
- * @property-read array $setters A reference to the Resolver $setters.
+ * @property array $setters A reference to the Resolver $setters.
  *
- * @property-read array $types A reference to the Resolver $types.
+ * @property array $types A reference to the Resolver $types.
  *
- * @property-read array $values A reference to the Resolver $values.
+ * @property array $values A reference to the Resolver $values.
  *
  */
 class Container implements ContainerInterface


### PR DESCRIPTION
Should allow IDEs to autocomplete the property and
not complain that the property is read only.

This is the 3.x fix for #91.
