### PR TITLE
Clarify the cause of each thrown exception.

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -124,7 +124,7 @@ class Container implements ContainerInterface
     public function &__get($key)
     {
         if ($this->isLocked()) {
-            throw new Exception\ContainerLocked();
+            throw new Exception\ContainerLocked('DI container is locked');
         }
 
         return $this->resolver->__get($key);
@@ -220,11 +220,11 @@ class Container implements ContainerInterface
     public function set($service, $val)
     {
         if ($this->isLocked()) {
-            throw new Exception\ContainerLocked();
+            throw new Exception\ContainerLocked('DI container is locked');
         }
 
         if (! is_object($val)) {
-            throw new Exception\ServiceNotObject($service);
+            throw new Exception\ServiceNotObject($service . ' not an object');
         }
 
         if ($val instanceof Closure) {
@@ -274,7 +274,7 @@ class Container implements ContainerInterface
     {
         // does the definition exist?
         if (! $this->has($service)) {
-            throw new Exception\ServiceNotFound($service);
+            throw new Exception\ServiceNotFound($service . ' does not exist');
         }
 
         // is it defined in this container?

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -98,7 +98,7 @@ class Resolver
         if (isset($this->$key)) {
             return $this->$key;
         }
-        throw new UnexpectedValueException($key);
+        throw new UnexpectedValueException('unexpected value for ' . $key);
     }
 
     /**
@@ -155,7 +155,7 @@ class Resolver
         $setters = array_merge($setters, $mergeSetters);
         foreach ($setters as $method => $value) {
             if (! method_exists($class, $method)) {
-                throw new Exception\SetterMethodNotFound("$class::$method");
+                throw new Exception\SetterMethodNotFound("setter method not found $class::$method");
             }
             if ($value instanceof LazyInterface) {
                 $setters[$method] = $value();
@@ -202,7 +202,7 @@ class Resolver
 
             // is the param missing?
             if ($val instanceof UnresolvedParam) {
-                throw new Exception\MissingParam($val->getName($class));
+                throw new Exception\MissingParam('missing param ' . $val->getName($class));
             }
 
             // load lazy objects as we go
@@ -236,7 +236,7 @@ class Resolver
         foreach ($params as $key => $val) {
             // is the param missing?
             if ($val instanceof UnresolvedParam) {
-                throw new Exception\MissingParam($val->getName($class));
+                throw new Exception\MissingParam('missing param ' . $val->getName($class));
             }
             // load lazy objects as we go
             if ($val instanceof LazyInterface) {


### PR DESCRIPTION
This also addresses the Radar issue #17, https://github.com/radarphp/Radar.Project/issues/17.

Adds a bit of explanatory text to each thrown exception so that the catching client can display a useful message.

Other possible solutions include:
1.  Add code to each custom derived class of the Exception class to do something intelligent, like add the text I've added, or call a user-supplied function to do something intelligent.
2.  Get rid of the custom derived Exception classes, and just instantiate the general purpose class.
