### PR TITLE
Add ability to pass object instance as config

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -89,7 +89,7 @@ class ContainerBuilder
         $configs = [];
         foreach ($configClasses as $configClass) {
             /** @var ContainerConfigInterface $config */
-            $config = new $configClass();
+            $config = $this->getConfig($configClass);
             $config->define($di);
             $configs[] = $config;
         }
@@ -101,5 +101,31 @@ class ContainerBuilder
         }
 
         return $di;
+    }
+
+    /**
+     *
+     * Get config object from connfig class or return the object
+     *
+     * @param mixed $config name of class to instantiate
+     *
+     * @return Object
+     * @throws InvalidArgumentException if invalid config
+     *
+     * @access protected
+     */
+    protected function getConfig($config)
+    {
+        if (is_string($config)) {
+            $config = new $config;
+        }
+
+        if (! $config instanceof ContainerConfigInterface) {
+            throw new \InvalidArgumentException(
+                'Container configs must implement ContainerConfigInterface'
+            );
+        }
+
+        return $config;
     }
 }

--- a/tests/ContainerBuilderTest.php
+++ b/tests/ContainerBuilderTest.php
@@ -39,6 +39,38 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual->baz);
     }
 
+    public function testNewConfiguredInstanceViaObject()
+    {
+        $config_classes = [
+            new \Aura\Di\Fake\FakeLibraryConfig,
+            new \Aura\Di\Fake\FakeProjectConfig,
+        ];
+
+        $di = $this->builder->newConfiguredInstance($config_classes);
+
+        $this->assertInstanceOf('Aura\Di\Container', $di);
+
+        $expect = 'zim';
+        $actual = $di->get('library_service');
+        $this->assertSame($expect, $actual->foo);
+
+        $expect = 'gir';
+        $actual = $di->get('project_service');
+        $this->assertSame($expect, $actual->baz);
+    }
+
+    public function testInvalid()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $di = $this->builder->newConfiguredInstance([[]]);
+    }
+
+    public function testInvalidDuckType()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $di = $this->builder->newConfiguredInstance([(object) []]);
+    }
+
     public function testSerializeAndUnserialize()
     {
         $di = $this->builder->newInstance();


### PR DESCRIPTION
- separate method to instantiate class if not object
- duck-type and except if invalid config

Firstly, I support the decision to lock the container.

However, I liked being able to write 'configuration that could be configured'.
When the ContainerConfig objects were resolved via the DI, I could set constructor params for them, or call setters in previously defined configs. That no longer is the case. 

In lieu of that, I kind of want the ability to pass an instantiated object to the builder.
So I can do things like this

``` php
<?php

$MyConfig = new My\Config('/path/to/cache');

$MyConfig->configRoutes(true)
    ->setUrlPrefix('/my')
    ->setOtherOption(false);

$builder->newConfiguredInstance(
    [
        $MyConfig,
        'Some\OtherConfig',
        'More\Configs'
    ]
);
```

I also added some duck-typing to the method that i added to instantiate the classes if they are strings and not objects. Honestly, I'd prefer to just check if instance of `ContainerConfigInterface`, but I'd also prefer that interfaces (ContainerInterface and ContainerConfigInterface) be a separated too. But further I just prefer container-interop adopt that ContainerInterface... but I'm probably getting ahead of myself. 

Thoughts?
