### PR TITLE
Fixes #116  closes #117 PR.

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -17,6 +17,7 @@ use Aura\Di\Injection\LazyInterface;
 use Aura\Di\Injection\LazyNew;
 use Aura\Di\Injection\LazyRequire;
 use Aura\Di\Injection\LazyValue;
+use Aura\Di\Resolver\AutoResolver;
 use Closure;
 use Interop\Container\ContainerInterface;
 
@@ -187,7 +188,11 @@ class Container implements ContainerInterface
 
     /**
      *
-     * Does a particular service definition exist?
+     * Check whether a particular service exist
+     * a. in this container?
+     * b. on delegate container?
+     * c. or if auto wiring is turned on try to register
+     * the service based on the class name.
      *
      * @param string $service The service key to look up.
      *
@@ -200,8 +205,22 @@ class Container implements ContainerInterface
             return true;
         }
 
-        return isset($this->delegateContainer)
-            && $this->delegateContainer->has($service);
+        if (isset($this->delegateContainer)
+            && $this->delegateContainer->has($service)
+        ) {
+            return true;
+        }
+
+        if ($this->resolver instanceof AutoResolver) {
+            try {
+                $this->services[$service] = $this->newInstance($service);
+                return true;
+            } catch (Exception $e) {
+                // do nothing
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -7,6 +7,7 @@ use Aura\Di\Injection\Factory;
 use Aura\Di\Injection\InjectionFactory;
 use Aura\Di\Resolver\Reflector;
 use Aura\Di\Resolver\Resolver;
+use Aura\Di\Resolver\AutoResolver;
 use Mouf\Picotainer\Picotainer;
 
 class ContainerTest extends \PHPUnit_Framework_TestCase
@@ -478,5 +479,16 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertInstanceOf('Aura\Di\Fake\FakeNullConstruct', $service);
+    }
+
+    public function testContainerExplicitlyRegisterService()
+    {
+        $container = new Container(new InjectionFactory(new AutoResolver(new Reflector())));
+        $service =  $container->get('Aura\Di\Fake\FakeOtherClass');
+
+        $this->assertInstanceOf('Aura\Di\Fake\FakeOtherClass', $service);
+
+        $service2 =  $container->get('Aura\Di\Fake\FakeOtherClass');
+        $this->assertSame($service, $service2);
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -491,4 +491,19 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $service2 =  $container->get('Aura\Di\Fake\FakeOtherClass');
         $this->assertSame($service, $service2);
     }
+
+    public function testContainerExplicitlyRegisterServiceButCanTakeParamsDefined()
+    {
+        $container = new Container(new InjectionFactory(new AutoResolver(new Reflector())));
+
+        $container->params['Aura\Di\Fake\FakeParentClass']['foo'] = 'another';
+
+        $service =  $container->get('Aura\Di\Fake\FakeResolveClass');
+        $parent = $service->getParentClass();
+
+        $this->assertInstanceOf('Aura\Di\Fake\FakeResolveClass', $service);
+        $this->assertInstanceOf('Aura\Di\Fake\FakeParentClass', $parent);
+
+        $this->assertEquals('another', $parent->getFoo());
+    }
 }

--- a/tests/Fake/FakeResolveClass.php
+++ b/tests/Fake/FakeResolveClass.php
@@ -8,4 +8,9 @@ class FakeResolveClass
     {
         $this->fake = $fake;
     }
+
+    public function getParentClass()
+    {
+        return $this->fake;
+    }
 }


### PR DESCRIPTION
If autowiring is enabled try to register the service when it is not
available in current container or in delegate container.
