### PR TITLE
Use LazyValue as filename for LazyInclude/LazyRequired

### DIFF
--- a/src/Injection/LazyInclude.php
+++ b/src/Injection/LazyInclude.php
@@ -21,7 +21,7 @@ class LazyInclude implements LazyInterface
      *
      * The file to include.
      *
-     * @var string
+     * @var string|LazyInterface
      *
      */
     protected $file;
@@ -30,7 +30,7 @@ class LazyInclude implements LazyInterface
      *
      * Constructor.
      *
-     * @param string $file The file to include.
+     * @param string|LazyInterface $file The file to include.
      *
      */
     public function __construct($file)
@@ -47,6 +47,10 @@ class LazyInclude implements LazyInterface
      */
     public function __invoke()
     {
-        return include $this->file;
+        $filename = $this->file;
+        if ($filename instanceof LazyInterface) {
+            $filename = $filename->__invoke();
+        }
+        return include $filename;
     }
 }

--- a/src/Injection/LazyRequire.php
+++ b/src/Injection/LazyRequire.php
@@ -21,7 +21,7 @@ class LazyRequire implements LazyInterface
      *
      * The file to require.
      *
-     * @var string
+     * @var string|LazyInterface
      *
      */
     protected $file;
@@ -30,7 +30,7 @@ class LazyRequire implements LazyInterface
      *
      * Constructor.
      *
-     * @param string $file The file to require.
+     * @param string|LazyInterface $file The file to require.
      *
      */
     public function __construct($file)
@@ -47,6 +47,10 @@ class LazyRequire implements LazyInterface
      */
     public function __invoke()
     {
-        return require $this->file;
+        $filename = $this->file;
+        if ($filename instanceof LazyInterface) {
+            $filename = $filename->__invoke();
+        }
+        return require $filename;
     }
 }

--- a/tests/Injection/LazyIncludeTest.php
+++ b/tests/Injection/LazyIncludeTest.php
@@ -1,0 +1,18 @@
+<?php
+namespace Aura\Di\Injection;
+
+class LazyIncludeTest extends \PHPUnit_Framework_TestCase
+{
+    public function test__invoke()
+    {
+        $file = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'lazy_array.php';
+        $lazyValueStub = $this->getMockBuilder('Aura\Di\Injection\LazyInterface')
+            ->getMock();
+        $lazyValueStub->method('__invoke')
+             ->willReturn($file);
+        $lazyInclude = new LazyInclude($lazyValueStub);
+        $actual = $lazyInclude->__invoke();
+        $expected = ['foo' => 'bar'];
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Injection/LazyRequireTest.php
+++ b/tests/Injection/LazyRequireTest.php
@@ -1,0 +1,18 @@
+<?php
+namespace Aura\Di\Injection;
+
+class LazyRequireTest extends \PHPUnit_Framework_TestCase
+{
+    public function test__invoke()
+    {
+        $file = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'lazy_array.php';
+        $lazyValueStub = $this->getMockBuilder('Aura\Di\Injection\LazyInterface')
+            ->getMock();
+        $lazyValueStub->method('__invoke')
+             ->willReturn($file);
+        $lazyInclude = new LazyRequire($lazyValueStub);
+        $actual = $lazyInclude->__invoke();
+        $expected = ['foo' => 'bar'];
+        $this->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
If we try to use LazyValue as filename for LazyInclude/LazyRequired, we'll get fatal error " Object of class Aura\Di\Injection\LazyValue could not be converted to string...". This PR allows to do smth like
`$di->lazyInclude($di->lazyValue('fooval'));`
