### PR TITLE
Allow direct use of lazies in Lazy

### DIFF
--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -167,4 +167,13 @@ $di->set('service', $di->lazy([$di->lazyNew('ServiceClass'), 'methodName'],
 ));
 ```
 
+You can also pass in lazies directly as the callable.
+
+```php
+$di->set('service', $di->lazy($di->lazyNew('InvokableServiceClass'),
+    $arg1,
+    $arg2
+));
+```
+
 Beware of relying on generic Lazy calls too much; if we do, it probably means we need to separate our configuration concerns better than we are currently doing.

--- a/src/Injection/Lazy.php
+++ b/src/Injection/Lazy.php
@@ -66,6 +66,8 @@ class Lazy implements LazyInterface
                     $this->callable[$key] = $val();
                 }
             }
+        } elseif ($this->callable instanceof LazyInterface) {
+            $this->callable = $this->callable->__invoke();
         }
 
         // convert Lazy objects in the params

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -186,6 +186,22 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function testLazy()
     {
         $lazy = $this->container->lazy(
+            $this->container->lazyNew('Aura\Di\Fake\FakeMeldingClass'),
+            $this->container->lazyNew('Aura\Di\Fake\FakeMalleableClass', ['foo' => 'bar'])
+        );
+
+        $this->assertInstanceOf('Aura\Di\Injection\Lazy', $lazy);
+        $meldingResult = $lazy();
+        $this->assertInstanceOf('Aura\Di\Fake\FakeMalleableClass', $meldingResult);
+
+        $actual = $meldingResult->getFoo();
+        $expect = 'baz';
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testLazyWithArrayContainingLazy()
+    {
+        $lazy = $this->container->lazy(
             [$this->container->lazyNew('Aura\Di\Fake\FakeParentClass'), 'mirror'],
             $this->container->lazy(function () { return 'foo'; })
         );

--- a/tests/Fake/FakeMalleableClass.php
+++ b/tests/Fake/FakeMalleableClass.php
@@ -1,0 +1,22 @@
+<?php
+namespace Aura\Di\Fake;
+
+class FakeMalleableClass
+{
+    protected $foo;
+
+    public function __construct($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+}

--- a/tests/Fake/FakeMeldingClass.php
+++ b/tests/Fake/FakeMeldingClass.php
@@ -1,0 +1,13 @@
+<?php
+namespace Aura\Di\Fake;
+
+class FakeMeldingClass
+{
+    protected $foo;
+
+    public function __invoke(FakeMalleableClass $object)
+    {
+        $object->setFoo('baz');
+        return $object;
+    }
+}


### PR DESCRIPTION
This increases the flexibility of the Lazy type. It allows you to use
other lazies directly, which means you can have (for example) a service
defined in the dependency injection container that is invokable whose
job it is to initialise and/or modify other services.
