### PR TITLE
Add a new LazyCallable type for injecting callable services

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -11,6 +11,7 @@ namespace Aura\Di;
 use Aura\Di\Injection\Factory;
 use Aura\Di\Injection\InjectionFactory;
 use Aura\Di\Injection\Lazy;
+use Aura\Di\Injection\LazyCallable;
 use Aura\Di\Injection\LazyGet;
 use Aura\Di\Injection\LazyInclude;
 use Aura\Di\Injection\LazyInterface;
@@ -342,6 +343,21 @@ class Container implements ContainerInterface
         $params = func_get_args();
         array_shift($params);
         return $this->injectionFactory->newLazy($callable, $params);
+    }
+
+    /**
+     *
+     * Returns a lazy object that invokes a (potentially lazy) callable with
+     * parameters supplied at calltime.
+     *
+     * @param callable $callable The (potentially lazy) callable.
+     *
+     * @return LazyCallable
+     *
+     */
+    public function lazyCallable($callable)
+    {
+        return $this->injectionFactory->newLazyCallable($callable);
     }
 
     /**

--- a/src/Injection/InjectionFactory.php
+++ b/src/Injection/InjectionFactory.php
@@ -120,6 +120,20 @@ class InjectionFactory
 
     /**
      *
+     * Returns a new LazyCallable.
+     *
+     * @param callable $callable The callable to invoke.
+     *
+     * @return LazyCallable
+     *
+     */
+    public function newLazyCallable($callable)
+    {
+        return new LazyCallable($callable);
+    }
+
+    /**
+     *
      * Returns a new LazyGet.
      *
      * @param ContainerInterface $container The service container.

--- a/src/Injection/LazyCallable.php
+++ b/src/Injection/LazyCallable.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+namespace Aura\Di\Injection;
+
+/**
+ *
+ * Returns the value of a callable with parameters supplied at calltime (thereby
+ * invoking the callable).
+ *
+ * @package Aura.Di
+ *
+ */
+class LazyCallable implements LazyInterface
+{
+    /**
+     *
+     * The callable to invoke.
+     *
+     * @var callable
+     *
+     */
+    protected $callable;
+
+    /**
+     *
+     * Whether or not the callable has been checked for instances of LazyInterface.
+     *
+     * @var bool
+     *
+     */
+    protected $callableChecked = false;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param callable $callable The callable to invoke.
+     *
+     */
+    public function __construct($callable)
+    {
+        $this->callable = $callable;
+    }
+
+    /**
+     *
+     * Invokes the closure (which may return a value).
+     *
+     * @return mixed The value returned by the invoked callable (if any).
+     *
+     */
+    public function __invoke()
+    {
+        if ($this->callableChecked === false) {
+            // convert Lazy objects in the callable
+            if (is_array($this->callable)) {
+                foreach ($this->callable as $key => $val) {
+                    if ($val instanceof LazyInterface) {
+                        $this->callable[$key] = $val();
+                    }
+                }
+            } elseif ($this->callable instanceof LazyInterface) {
+                $this->callable = $this->callable->__invoke();
+            }
+            $this->callableChecked = true;
+        }
+
+        // make the call
+        return call_user_func_array($this->callable, func_get_args());
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -196,6 +196,33 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
 
+    public function testLazyCallable()
+    {
+        $lazyCallable = $this->container->lazyCallable($this->container->lazyNew('Aura\Di\Fake\FakeInvokableClass'));
+        $callableRunner = function(callable $callable) {
+            return $callable('baz');
+        };
+
+        $this->assertInstanceOf('Aura\Di\Injection\LazyCallable', $lazyCallable);
+        $actual = $callableRunner($lazyCallable);
+        $expect = 'barbaz';
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testLazyCallableWithArrayContainingLazy()
+    {
+        $this->container->set('invokable_class', $this->container->lazyNew('Aura\Di\Fake\FakeInvokableClass', array('foo' => 'foo')));
+        $lazyCallable = $this->container->lazyCallable([$this->container->lazyGet('invokable_class'), '__invoke']);
+        $callableRunner = function(callable $callable) {
+            return $callable('bar');
+        };
+
+        $this->assertInstanceOf('Aura\Di\Injection\LazyCallable', $lazyCallable);
+        $actual = $callableRunner($lazyCallable);
+        $expect = 'foobar';
+        $this->assertSame($expect, $actual);
+    }
+
     public function testLazyGetCall()
     {
         $this->container->set(

--- a/tests/Fake/FakeInvokableClass.php
+++ b/tests/Fake/FakeInvokableClass.php
@@ -1,0 +1,17 @@
+<?php
+namespace Aura\Di\Fake;
+
+class FakeInvokableClass
+{
+    protected $foo;
+
+    public function __construct($foo = 'bar')
+    {
+        $this->foo = $foo;
+    }
+
+    public function __invoke($value)
+    {
+        return $this->foo . $value;
+    }
+}


### PR DESCRIPTION
It's possible for code to expect to take a callable and invoke it
multiple times (sequentially, not recursively) with parameters that are
only known at calltime. This patch makes it possible to use services
configured in the dependency injection container as callables that fit
the above definition.

The LazyCallable type differs from the Lazy type in two ways:
1. Lazy expects all callable parameters to be configured when it is
   created. LazyCallable expects all callable parameters to be supplied
   at calltime.
2. Lazy expects to only be called once. LazyCallable expects to be
   called multiple times.
