### PR TITLE
fix missed  parameter for LazyValue object

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -414,9 +414,9 @@ class Container implements ContainerInterface
      * @return LazyValue
      *
      */
-    public function lazyValue($key)
+    public function lazyValue($values, $key)
     {
-        return $this->factory->newLazyValue($key);
+        return $this->factory->newLazyValue($values, $key);
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -228,9 +228,9 @@ class Factory
      * @return LazyValue
      *
      */
-    public function newLazyValue($key)
+    public function newLazyValue($values, $key)
     {
-        return new LazyValue($this->values, $key);
+        return new LazyValue($values, $key);
     }
 
     /**


### PR DESCRIPTION
Hi,
I've found that 2.x:$di->LazyValue($array, $key) doesn't work correctly. There is a fix.
