### PR TITLE
Add a new LazyArray type for injecting arrays of callables

### DIFF
--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -125,6 +125,23 @@ $di->params['Example1']['data'] = $di->lazyInclude('/path/to/data.php');
 $di->params['Example2']['data'] = $di->lazyRequire('/path/to/data.php');
 ```
 
+## Lazy Array
+
+Sometimes you'll be working with code that expects an array of objects. If you want to have the objects within the array to be lazy you can use the `$di->lazyArray()` method. This will iterate through your array and resolve any lazy objects before returning the array.
+
+```php
+$di->setters['Example']['addFoos'] = $di->lazyArray([
+    $di->lazyNew('FirstFoo'),
+    $di->lazyNew('SecondFoo'),
+]);
+
+// Nesting Lazy Arrays
+$di->setters['Example']['addBars'] = $di->lazyArray([
+    $di->lazyArray(['name1', $di->lazyNew('FirstBar), 'en']),
+    $di->lazyArray(['name2', $di->lazyNew('SecondFoo'), 'es']),
+]);
+```
+
 ## Lazy Callable
 
 Sometimes you'll be working with code that deals with callables. This code may expect to invoke the callable once, or many times. If you wanted to use a service in this situation, you can use the ``lazyCallable`` method. This will produce a callable that will lazily resolve other lazies, and ensure that all calls to the service are made appropriately.

--- a/src/Container.php
+++ b/src/Container.php
@@ -11,6 +11,7 @@ namespace Aura\Di;
 use Aura\Di\Injection\Factory;
 use Aura\Di\Injection\InjectionFactory;
 use Aura\Di\Injection\Lazy;
+use Aura\Di\Injection\LazyArray;
 use Aura\Di\Injection\LazyCallable;
 use Aura\Di\Injection\LazyGet;
 use Aura\Di\Injection\LazyInclude;
@@ -343,6 +344,21 @@ class Container implements ContainerInterface
         $params = func_get_args();
         array_shift($params);
         return $this->injectionFactory->newLazy($callable, $params);
+    }
+
+    /**
+     *
+     * Returns a lazy object that wraps an array that may contain
+     * (potentially lazy) callables that get invoked at calltime.
+     *
+     * @param array $callables The (potentially lazy) array of callables to invoke.
+     *
+     * @return LazyArray
+     *
+     */
+    public function lazyArray(array $callables)
+    {
+        return $this->injectionFactory->newLazyArray($callables);
     }
 
     /**

--- a/src/Injection/InjectionFactory.php
+++ b/src/Injection/InjectionFactory.php
@@ -120,6 +120,20 @@ class InjectionFactory
 
     /**
      *
+     * Returns a new LazyArray.
+     *
+     * @param array $callables The callables to invoke.
+     *
+     * @return LazyArray
+     *
+     */
+    public function newLazyArray(array $callables)
+    {
+        return new LazyArray($callables);
+    }
+
+    /**
+     *
      * Returns a new LazyCallable.
      *
      * @param callable $callable The callable to invoke.

--- a/src/Injection/LazyArray.php
+++ b/src/Injection/LazyArray.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+namespace Aura\Di\Injection;
+
+/**
+ *
+ * Returns the value of a callable when invoked (thereby invoking the callable).
+ *
+ * @package Aura.Di
+ *
+ */
+class LazyArray implements LazyInterface
+{
+    /**
+     *
+     * Array of callables to invoke.
+     *
+     * @var array
+     *
+     */
+    protected $callables;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param array $callables The callables to invoke.
+     *
+     */
+    public function __construct(array $callables)
+    {
+        $this->callables = $callables;
+    }
+
+    /**
+     *
+     * Invokes the array of closures to create the instance array.
+     *
+     * @return array The array of objects created by the closures.
+     *
+     */
+    public function __invoke()
+    {
+        // convert Lazy objects in the callables
+        if (is_array($this->callables)) {
+            foreach ($this->callables as $key => $val) {
+                if ($val instanceof LazyInterface) {
+                    $this->callables[$key] = $val();
+                }
+            }
+        }
+
+        // return array
+        return $this->callables;
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -212,6 +212,19 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
 
+    public function testLazyArray()
+    {
+        $lazyArray = $this->container->lazyArray([
+            $this->container->lazyNew('Aura\Di\Fake\FakeOtherClass'),
+        ]);
+
+        $this->assertInstanceOf('Aura\Di\Injection\LazyArray', $lazyArray);
+        $actual = $lazyArray();
+        $this->assertInternalType('array', $actual);
+        $this->assertArrayHasKey(0, $actual);
+        $this->assertInstanceOf('Aura\Di\Fake\FakeOtherClass', $actual[0]);
+    }
+
     public function testLazyCallable()
     {
         $lazyCallable = $this->container->lazyCallable($this->container->lazyNew('Aura\Di\Fake\FakeInvokableClass'));


### PR DESCRIPTION
I'm working with Symfony Forms and there is currently no way to assign via setter injection multiple times (like calling addExtension three times).

However, they do have an addExtensions method that takes an array of extensions. However, when I assign an array to it with several lazy objects, the lazy objects do not get called to create the real objects before being passed into the method.

I created a LazyArray class that is a flat array of values and when invoked I go through the array and if it's a LazyInstance I call it and replace it with the real value.  Then I just return the array of real instances.

If you have a nested array you can nest LazyArrays and it will resolve correctly.
