### PR TITLE
psr-11 support with 1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "container-interop/container-interop": "~1.0"
+        "container-interop/container-interop": "^1.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Container Interoperability is extending psr-11 https://github.com/container-interop/container-interop/blob/79cbf1341c22ec75643d841642dd5d6acd83bdb8/src/Interop/Container/ContainerInterface.php . So we don't need anything for now.