### PR TITLE
Add Config Collection

### DIFF
--- a/src/ConfigCollection.php
+++ b/src/ConfigCollection.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+
+namespace Aura\Di;
+
+/**
+ *
+ * A collection of Container config instructions
+ *
+ * @package Aura.Di
+ *
+ */
+class ConfigCollection extends ContainerConfig
+{
+    /**
+     * Configs
+     *
+     * @var ContainerConfigInterface[]
+     *
+     * @access protected
+     */
+    protected $configs = [];
+
+    /**
+     * __construct
+     *
+     * @param array $configs A list of ContainerConfig classes to
+     * instantiate and invoke for configuring the Container.
+     *
+     * @access public
+     */
+    public function __construct(array $configs)
+    {
+        foreach ($configs as $config) {
+            $config = $this->getConfig($config);
+            $this->configs[] = $config;
+        }
+    }
+
+
+    /**
+     *
+     * Get config object from connfig class or return the object
+     *
+     * @param mixed $config name of class to instantiate
+     *
+     * @return ContainerConfigInterface
+     *
+     * @throws InvalidArgumentException if invalid config
+     *
+     * @access protected
+     */
+    protected function getConfig($config)
+    {
+        if (is_string($config)) {
+            $config = new $config;
+        }
+
+        if (! $config instanceof ContainerConfigInterface) {
+            throw new \InvalidArgumentException(
+                'Container configs must implement ContainerConfigInterface'
+            );
+        }
+
+        return $config;
+    }
+
+    /**
+     *
+     * Define params, setters, and services for each of the configs before the
+     * Container is locked.
+     *
+     * @param Container $di The DI container.
+     *
+     * @return null
+     *
+     */
+    public function define(Container $di)
+    {
+        foreach ($this->configs as $config) {
+            $config->define($di);
+        }
+    }
+
+    /**
+     *
+     * Modify service objects for each config after the Container is locked.
+     *
+     * @param Container $di The DI container.
+     *
+     * @return null
+     *
+     */
+    public function modify(Container $di)
+    {
+        foreach ($this->configs as $config) {
+            $config->modify($di);
+        }
+    }
+}
+
+
+
+

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -85,47 +85,28 @@ class ContainerBuilder
         $autoResolve = false
     ) {
         $di = $this->newInstance($autoResolve);
+        $collection = $this->newConfigCollection($configClasses);
 
-        $configs = [];
-        foreach ($configClasses as $configClass) {
-            /** @var ContainerConfigInterface $config */
-            $config = $this->getConfig($configClass);
-            $config->define($di);
-            $configs[] = $config;
-        }
-
+        $collection->define($di);
         $di->lock();
-
-        foreach ($configs as $config) {
-            $config->modify($di);
-        }
+        $collection->modify($di);
 
         return $di;
     }
 
     /**
      *
-     * Get config object from connfig class or return the object
+     * Creates a new ContainerConfig for a collection of
+     * ContainerConfigInterface classes
      *
-     * @param mixed $config name of class to instantiate
      *
-     * @return Object
-     * @throws InvalidArgumentException if invalid config
+     * @param array $configClasses A list of ContainerConfig classes to
+     * instantiate and invoke for configuring the Container.
      *
-     * @access protected
+     * @return ConfigCollection
      */
-    protected function getConfig($config)
+    protected function newConfigCollection(array $configClasses = [])
     {
-        if (is_string($config)) {
-            $config = new $config;
-        }
-
-        if (! $config instanceof ContainerConfigInterface) {
-            throw new \InvalidArgumentException(
-                'Container configs must implement ContainerConfigInterface'
-            );
-        }
-
-        return $config;
+        return new ConfigCollection($configClasses);
     }
 }


### PR DESCRIPTION
I've been breaking up my `ContainerConfig` classes into smaller little discrete chunks for organizational and reuse purposes. What I often end up with are configs like `Service\Config` or whatever, that then just delegates to a bunch of other configs. 

I end up basically duplicating the functionality in the `ContainerBuilder` (instantiating classes, checking interface, calling define, calling modify), so I thought perhaps it might be useful to pull it out into its own class, so I can just extend that instead.

I end up with something like this:

```php
<?php
//@codingStandardsIgnoreFile

// src/
// ├── Config.php
// ├── Data
// │   └── Config.php
// ├── Service
// │   ├── Config.php
// │   ├── Posts
// │   │   └── Config.php
// │   └── Users
// │       └── Config.php
// ├── View
// │   ├── Config.php
// │   └── Helpers
// │       └── Config.php
// └── Web
//     ├── Config
//     │   ├── Middleware.php
//     │   └── Routes.php
//     └── Config.php


$builder->newConfiguredInstance([App\Config::class]);


// NS My\App
class Config extends ConfigCollection
{
    protected $packages = [
        Data\Config::class,
        Service\Config::class,
        View\Config::class,
        Web\Config::class,
    ];

    public function __construct()
    {
        parent::__construct($this->packages);
    }
}


// NS My\App\Web
class Config extends ConfigCollection
{
    protected $packages = [
        Config\Routes::class,
        Config\Middleware::class,
    ];

    public function __construct()
    {
        parent::__construct($this->packages);
    }
}

// NS My\App\Service
class Config extends ConfigCollection
{
    protected $packages = [
        Posts\Config::class,
        Users\Config::class
    ];

    public function __construct()
    {
        parent::__construct($this->packages);
    }
}
```


Thoughts?