### PR TITLE
Make LazyArray an ArrayObject

### DIFF
--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -133,7 +133,7 @@ $di->params['Example2']['data'] = $di->lazyRequire('/path/to/data.php');
 
 ## Lazy Array
 
-Sometimes you'll be working with code that expects an array of objects. If you want to have the objects within the array to be lazy you can use the `$di->lazyArray()` method. This will iterate through your array and resolve any lazy objects before returning the array.
+Sometimes you'll be working with code that expects an array of objects. If you want the objects within the array to be lazy, you can use the `$di->lazyArray()` method. This will iterate through your array and resolve any lazy objects before returning the array.
 
 ```php
 $di->setters['Example']['addFoos'] = $di->lazyArray([
@@ -146,6 +146,24 @@ $di->setters['Example']['addBars'] = $di->lazyArray([
     $di->lazyArray(['name1', $di->lazyNew('FirstBar'), 'en']),
     $di->lazyArray(['name2', $di->lazyNew('SecondFoo'), 'es']),
 ]);
+```
+
+If you need to modify the LazyArray after you've assigned it we provide two methods (`append($value, $key = null)` and `getArrayCopy()` to help.
+
+```php
+$di->setters['Example']['addFoos'] = $di->lazyArray([]);
+
+// Append to array
+$di->setters['Example']['addFoos']->append($di->lazyNew('SecondFoo'));
+
+// Get a copy of the internal array
+$copy = $di->setters['Example']['addFoos']->getArrayCopy();
+
+// Manipulate the array
+array_unshift($copy, $di->lazyNew('FirstFoo'));
+
+// Reassign with new array
+$di->setters['Example']['addFoos'] = $di->lazyArray($copy);
 ```
 
 ## Lazy Callable

--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -148,7 +148,7 @@ $di->setters['Example']['addBars'] = $di->lazyArray([
 ]);
 ```
 
-If you need to modify the LazyArray after you've assigned it we provide two methods (`append($value, $key = null)` and `getArrayCopy()` to help.
+LazyArray extends [ArrayObject](http://php.net/manual/en/class.arrayobject.php) so if you need to modify the LazyArray after you've assigned it you can use any of the `ArrayObject` methods.
 
 ```php
 $di->setters['Example']['addFoos'] = $di->lazyArray([]);

--- a/src/Injection/LazyArray.php
+++ b/src/Injection/LazyArray.php
@@ -8,6 +8,8 @@
  */
 namespace Aura\Di\Injection;
 
+use ArrayObject;
+
 /**
  *
  * Returns the value of a callable when invoked (thereby invoking the callable).
@@ -15,74 +17,26 @@ namespace Aura\Di\Injection;
  * @package Aura.Di
  *
  */
-class LazyArray implements LazyInterface
+class LazyArray extends ArrayObject implements LazyInterface
 {
-    /**
-     *
-     * Array of callables to invoke.
-     *
-     * @var array
-     *
-     */
-    protected $callables = [];
 
     /**
      *
-     * Constructor.
+     * Invoke any LazyInterface in the array.
      *
-     * @param array $callables The callables to invoke.
-     *
-     */
-    public function __construct(array $callables)
-    {
-        $this->callables = $callables;
-    }
-
-    /**
-     *
-     * Append a callable to the array
-     *
-     * @param mixed $callable Callable to append to array
-     *
-     */
-    public function append($callable, $key = null)
-    {
-        if (is_null($key)) {
-            $this->callables[] = $callable;
-        } else {
-            $this->callables[$key] = $callable;
-        }
-    }
-
-    /**
-     *
-     * Return the uninvoked array of callables
-     *
-     * @return array The uninvoked array of callables
-     *
-     */
-    public function getArrayCopy()
-    {
-        return $this->callables;
-    }
-
-    /**
-     *
-     * Invokes the array of closures to create the instance array.
-     *
-     * @return array The array of objects created by the closures.
+     * @return array The array of potentially invoked items.
      *
      */
     public function __invoke()
     {
         // convert Lazy objects in the callables
-        foreach ($this->callables as $key => $val) {
+        foreach ($this as $key => $val) {
             if ($val instanceof LazyInterface) {
-                $this->callables[$key] = $val();
+                $this[$key] = $val();
             }
         }
 
         // return array
-        return $this->callables;
+        return $this->getArrayCopy();
     }
 }

--- a/src/Injection/LazyArray.php
+++ b/src/Injection/LazyArray.php
@@ -40,6 +40,34 @@ class LazyArray implements LazyInterface
 
     /**
      *
+     * Append a callable to the array
+     *
+     * @param mixed $callable Callable to append to array
+     *
+     */
+    public function append($callable, $key = null)
+    {
+        if (is_null($key)) {
+            $this->callables[] = $callable;
+        } else {
+            $this->callables[$key] = $callable;
+        }
+    }
+
+    /**
+     *
+     * Return the uninvoked array of callables
+     *
+     * @return array The uninvoked array of callables
+     *
+     */
+    public function getArrayCopy()
+    {
+        return $this->callables;
+    }
+
+    /**
+     *
      * Invokes the array of closures to create the instance array.
      *
      * @return array The array of objects created by the closures.

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -246,7 +246,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function testLazyArrayAppendWithKey()
     {
         $lazyArray = $this->container->lazyArray([]);
-        $lazyArray->append($this->container->lazyNew('Aura\Di\Fake\FakeOtherClass'), 'fake');
+        $lazyArray['fake'] = $this->container->lazyNew('Aura\Di\Fake\FakeOtherClass');
 
         $actual = $lazyArray();
         $this->assertInternalType('array', $actual);
@@ -257,7 +257,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function testLazyArrayGetArrayCopy()
     {
         $lazyArray = $this->container->lazyArray([]);
-        $lazyArray->append($this->container->lazyNew('Aura\Di\Fake\FakeOtherClass'), 'fake');
+        $lazyArray['fake'] = $this->container->lazyNew('Aura\Di\Fake\FakeOtherClass');
 
         $copy = $lazyArray->getArrayCopy();
         $this->assertInternalType('array', $copy);

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -232,6 +232,39 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Aura\Di\Fake\FakeOtherClass', $actual[0]);
     }
 
+    public function testLazyArrayAppend()
+    {
+        $lazyArray = $this->container->lazyArray([]);
+        $lazyArray->append($this->container->lazyNew('Aura\Di\Fake\FakeOtherClass'));
+
+        $actual = $lazyArray();
+        $this->assertInternalType('array', $actual);
+        $this->assertArrayHasKey(0, $actual);
+        $this->assertInstanceOf('Aura\Di\Fake\FakeOtherClass', $actual[0]);
+    }
+
+    public function testLazyArrayAppendWithKey()
+    {
+        $lazyArray = $this->container->lazyArray([]);
+        $lazyArray->append($this->container->lazyNew('Aura\Di\Fake\FakeOtherClass'), 'fake');
+
+        $actual = $lazyArray();
+        $this->assertInternalType('array', $actual);
+        $this->assertArrayHasKey('fake', $actual);
+        $this->assertInstanceOf('Aura\Di\Fake\FakeOtherClass', $actual['fake']);
+    }
+
+    public function testLazyArrayGetArrayCopy()
+    {
+        $lazyArray = $this->container->lazyArray([]);
+        $lazyArray->append($this->container->lazyNew('Aura\Di\Fake\FakeOtherClass'), 'fake');
+
+        $copy = $lazyArray->getArrayCopy();
+        $this->assertInternalType('array', $copy);
+        $this->assertArrayHasKey('fake', $copy);
+        $this->assertInstanceOf('Aura\Di\Injection\LazyNew', $copy['fake']);
+    }
+
     public function testLazyCallable()
     {
         $lazyCallable = $this->container->lazyCallable($this->container->lazyNew('Aura\Di\Fake\FakeInvokableClass'));


### PR DESCRIPTION
I found it would be useful to be able to manipulate a `LazyArray` after it's been instantiated.

This would be most useful if you had multiple containers that interacted with a specific class. For instance different containers that wanted to add middleware or extensions to a class.