### PR TITLE
Travis CI requires Trusty for hhvm testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: php
+dist: trusty
 php:
   - 5.5
   - 5.6


### PR DESCRIPTION
I noticed when I submitted my last pull request that the hhvm test failed because Travis CI now requires Ubuntu Trusty for hhvm.  This pull request adds the config option to use Ubuntu Trusty which should fix Travis CI.