### PR TITLE
Elaborated on docs for AUTO_RESOLVE parameter.

### DIFF
--- a/docs/auto.md
+++ b/docs/auto.md
@@ -2,7 +2,7 @@
 
 Some developers prefer to let the _Container_ resolve dependencies on its own, without having to specify anything in a configuration file. Note that there can be unusual debugging problems inherent in tracking down the default injections, so auto-resolution may or may not be your preference.
 
-To use auto-resolution in a _Container_, build the _Container_ with `$container = $builder->newInstance($builder::AUTO_RESOLVE)`.
+To use auto-resolution in a _Container_, build the _Container_ with `$container = $builder->newInstance($builder::AUTO_RESOLVE)`. If you're using `newConfiguredInstance` to configure your dependency injector and want this functionality, you will need to pass `$builder::AUTO_RESOLVE` as the second parameter.
 
 Note that auto-resolution only works for class/interface typehints. It does not work for `array` typehints.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,6 +20,8 @@ $di = $container_builder->newConfiguredInstance([
 ]);
 ```
 
+**Note:** As with the `newInstance` method of the `ContainerBuilder`, you will have to pass `$container_builder::AUTO_RESOLVE` to `newConfiguredInstance` (as the second parameter) if you want to enable auto-resolution.
+
 A configuration class looks like the following:
 
 ```php


### PR DESCRIPTION
Added more information about where it's necessary to use the
ContainerBuilder::AUTO_RESOLVE constant.

This should resolve #154.