### PR TITLE
Revert "Revert "Added support for variadic constructor parameters""

### DIFF
--- a/src/Injection/Factory.php
+++ b/src/Injection/Factory.php
@@ -104,7 +104,9 @@ class Factory
             $this->setters
         );
 
-        $object = $resolve->reflection->newInstanceArgs($resolve->params);
+        $expandedParams = $this->resolver->getExpandedParams($this->class, $resolve->params);
+        $object = $resolve->reflection->newInstanceArgs($expandedParams);
+
         foreach ($resolve->setters as $method => $value) {
             $object->$method($value);
         }

--- a/src/Injection/InjectionFactory.php
+++ b/src/Injection/InjectionFactory.php
@@ -8,10 +8,8 @@
  */
 namespace Aura\Di\Injection;
 
-use Aura\Di\Container;
 use Aura\Di\Resolver\Resolver;
 use Interop\Container\ContainerInterface;
-use ReflectionException;
 
 /**
  *
@@ -74,7 +72,10 @@ class InjectionFactory
         array $setters = []
     ) {
         $resolve = $this->resolver->resolve($class, $params, $setters);
-        $object = $resolve->reflection->newInstanceArgs($resolve->params);
+
+        $expandedParams = $this->resolver->getExpandedParams($class, $resolve->params);
+        $object = $resolve->reflection->newInstanceArgs($expandedParams);
+
         foreach ($resolve->setters as $method => $value) {
             $object->$method($value);
         }

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -410,4 +410,33 @@ class Resolver
         // done
         return $unified;
     }
+
+    /**
+     * Expands variadic parameters onto the end of a contructor parameters array.
+     *
+     * @param type $class The class name to expand parameters for.
+     *
+     * @param array $params An array of constructor parameters and values.
+     *
+     * @return array The expanded constructor parameters.
+     */
+    public function getExpandedParams($class, array $params)
+    {
+        // Variadics are only available in PHP >= 5.6, and not in HHVM
+        if (version_compare(PHP_VERSION, '5.6') === -1 || defined('HHVM_VERSION')) {
+            return $params;
+        }
+
+        $variadicParams = [];
+        foreach ($this->reflector->getParams($class) as $reflectParam) {
+            $paramName = $reflectParam->getName();
+            if ($reflectParam->isVariadic() && is_array($params[$paramName])) {
+                $variadicParams = array_merge($variadicParams, $params[$paramName]);
+                unset($params[$paramName]);
+                break; // There can only be one
+            }
+        }
+
+        return array_merge($params, array_values($variadicParams));
+    }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -148,12 +148,45 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
 
+    public function testNewInstanceWithVariadic()
+    {
+        // Variadics are only available in PHP >= 5.6, and not in HHVM
+        if (version_compare(PHP_VERSION, '5.6') === -1 || defined('HHVM_VERSION')) {
+            $this->markTestSkipped();
+        }
+        $foo = 'bar';
+        $items = [(object) ['id' => 1], (object) ['id' => 2]];
+        $instance = $this->container->newInstance(
+            'Aura\Di\Fake\FakeVariadic',
+            ['foo' => $foo, 'items' => $items]
+        );
+        $this->assertSame($foo, $instance->getFoo());
+        $this->assertSame($items, $instance->getItems());
+    }
+
     public function testLazyNew()
     {
         $lazy = $this->container->lazyNew('Aura\Di\Fake\FakeOtherClass');
         $this->assertInstanceOf('Aura\Di\Injection\LazyNew', $lazy);
         $foo = $lazy();
         $this->assertInstanceOf('Aura\Di\Fake\FakeOtherClass', $foo);
+    }
+
+    public function testLazyNewWithVariadic()
+    {
+        // Variadics are only available in PHP >= 5.6, and not in HHVM
+        if (version_compare(PHP_VERSION, '5.6') === -1 || defined('HHVM_VERSION')) {
+            $this->markTestSkipped();
+        }
+        $foo = 'bar';
+        $items = [(object) ['id' => 1], (object) ['id' => 2]];
+        $lazy = $this->container->lazyNew(
+            'Aura\Di\Fake\FakeVariadic',
+            ['foo' => $foo, 'items' => $items]
+        );
+        $instance = $lazy();
+        $this->assertSame($foo, $instance->getFoo());
+        $this->assertSame($items, $instance->getItems());
     }
 
     public function testLockedMagicGet()

--- a/tests/Fake/FakeVariadic.php
+++ b/tests/Fake/FakeVariadic.php
@@ -1,0 +1,24 @@
+<?php
+namespace Aura\Di\Fake;
+
+class FakeVariadic
+{
+    protected $foo;
+    protected $items;
+
+    public function __construct($foo, \stdClass ...$items)
+    {
+        $this->foo = $foo;
+        $this->items = $items;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function getItems()
+    {
+        return $this->items;
+    }
+}


### PR DESCRIPTION
I am really sorry about this. The PR #167 was correct. 
The example I tested was the one that failed.

The setter was not considered.