### PR TITLE
Add type hints, PHP7.2+ only, upgrade to phpunit 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor
+/.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ sudo: false
 language: php
 dist: trusty
 php:
-  - 5.5
-  - 5.6
-  - 7
-  - 7.1
+  - 7.2
+  - 7.3
   - nightly
-  - hhvm
 before_script:
   - composer self-update
   - composer install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 4.0.0
+
+- Upgrade to PHP 7.2+ only, strict types enabled
+- Dropped HHVM support
+- Signatures of methods in ContainerConfigInterface changed.
+- LazyRequire and LazyInclude do not accept another lazy
+- Removed container interop dependency
+
 ## 3.4.0
 
 - (CHG) LazyArray now extends ArrayObject. PR #151.

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "container-interop/container-interop": "~1.0"
+        "php": ">=7.2.0",
+        "psr/container": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,9 +27,8 @@
         }
     },
     "require-dev": {
-        "mouf/picotainer": "~1.0",
-        "acclimate/container": "~1.0",
-        "phpunit/phpunit": "~5.7 || ~4.8"
+        "acclimate/container": "^2",
+        "phpunit/phpunit": "^7"
     },
     "autoload-dev": {
         "psr-4": {
@@ -37,6 +36,6 @@
         }
     },
     "provide": {
-        "container-interop/container-interop-implementation": "^1.0"
+        "psr/container-implementation": "^1.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,13 @@
-<phpunit bootstrap="./phpunit.php">
+<phpunit bootstrap="./phpunit.php"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
+
     <testsuites>
-        <testsuite>
+        <testsuite name="unit tests">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>

--- a/src/ConfigCollection.php
+++ b/src/ConfigCollection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -52,11 +53,11 @@ class ConfigCollection extends ContainerConfig
      *
      * @return ContainerConfigInterface
      *
-     * @throws InvalidArgumentException if invalid config
+     * @throws \InvalidArgumentException if invalid config
      *
      * @access protected
      */
-    protected function getConfig($config)
+    protected function getConfig($config): ContainerConfigInterface
     {
         if (is_string($config)) {
             $config = new $config;
@@ -78,10 +79,8 @@ class ConfigCollection extends ContainerConfig
      *
      * @param Container $di The DI container.
      *
-     * @return null
-     *
      */
-    public function define(Container $di)
+    public function define(Container $di): void
     {
         foreach ($this->configs as $config) {
             $config->define($di);
@@ -94,10 +93,8 @@ class ConfigCollection extends ContainerConfig
      *
      * @param Container $di The DI container.
      *
-     * @return null
-     *
      */
-    public function modify(Container $di)
+    public function modify(Container $di): void
     {
         foreach ($this->configs as $config) {
             $config->modify($di);

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -40,7 +41,7 @@ class ContainerBuilder
      * @return Container
      *
      */
-    public function newInstance($autoResolve = false)
+    public function newInstance(bool $autoResolve = false): Container
     {
         $resolver = $this->newResolver($autoResolve);
         return new Container(new InjectionFactory($resolver));
@@ -55,7 +56,7 @@ class ContainerBuilder
      * @return Resolver
      *
      */
-    protected function newResolver($autoResolve = false)
+    protected function newResolver(bool $autoResolve = false): Resolver
     {
         if ($autoResolve) {
             return new AutoResolver(new Reflector());
@@ -82,8 +83,8 @@ class ContainerBuilder
      */
     public function newConfiguredInstance(
         array $configClasses = [],
-        $autoResolve = false
-    ) {
+        bool $autoResolve = false
+    ): Container {
         $di = $this->newInstance($autoResolve);
         $collection = $this->newConfigCollection($configClasses);
 
@@ -105,7 +106,7 @@ class ContainerBuilder
      *
      * @return ConfigCollection
      */
-    protected function newConfigCollection(array $configClasses = [])
+    protected function newConfigCollection(array $configClasses = []): ConfigCollection
     {
         return new ConfigCollection($configClasses);
     }

--- a/src/ContainerConfig.php
+++ b/src/ContainerConfig.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -23,10 +24,8 @@ class ContainerConfig implements ContainerConfigInterface
      *
      * @param Container $di The DI container.
      *
-     * @return null
-     *
      */
-    public function define(Container $di)
+    public function define(Container $di): void
     {
     }
 
@@ -36,10 +35,8 @@ class ContainerConfig implements ContainerConfigInterface
      *
      * @param Container $di The DI container.
      *
-     * @return null
-     *
      */
-    public function modify(Container $di)
+    public function modify(Container $di): void
     {
     }
 }

--- a/src/ContainerConfigInterface.php
+++ b/src/ContainerConfigInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -23,10 +24,8 @@ interface ContainerConfigInterface
      *
      * @param Container $di The DI container.
      *
-     * @return null
-     *
      */
-    public function define(Container $di);
+    public function define(Container $di): void;
 
     /**
      *
@@ -34,8 +33,6 @@ interface ContainerConfigInterface
      *
      * @param Container $di The DI container.
      *
-     * @return null
-     *
      */
-    public function modify(Container $di);
+    public function modify(Container $di): void;
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -8,7 +9,7 @@
  */
 namespace Aura\Di;
 
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  *
@@ -17,7 +18,7 @@ use Interop\Container\Exception\ContainerException;
  * @package Aura.Di
  *
  */
-class Exception extends \Exception implements ContainerException
+class Exception extends \Exception implements ContainerExceptionInterface
 {
     /**
      *
@@ -26,7 +27,7 @@ class Exception extends \Exception implements ContainerException
      * @return Exception\ContainerLocked
      *
      */
-    static public function containerLocked()
+    static public function containerLocked(): Exception\ContainerLocked
     {
         throw new Exception\ContainerLocked("Cannot modify container when locked.");
     }
@@ -42,7 +43,7 @@ class Exception extends \Exception implements ContainerException
      * @return Exception\MissingParam
      *
      */
-    static public function missingParam($class, $param)
+    static public function missingParam(string $class, string $param): Exception\MissingParam
     {
         throw new Exception\MissingParam("Param missing: {$class}::\${$param}");
     }
@@ -56,7 +57,7 @@ class Exception extends \Exception implements ContainerException
      * @return Exception\ServiceNotFound
      *
      */
-    static public function serviceNotFound($service)
+    static public function serviceNotFound(string $service): Exception\ServiceNotFound
     {
         throw new Exception\ServiceNotFound("Service not defined: '{$service}'");
     }
@@ -72,7 +73,7 @@ class Exception extends \Exception implements ContainerException
      * @return Exception\ServiceNotObject
      *
      */
-    static public function serviceNotObject($service, $val)
+    static public function serviceNotObject(string $service, $val): Exception\ServiceNotObject
     {
         $type = gettype($val);
         $message = "Expected service '{$service}' to be of type 'object', got '{$type}' instead.";
@@ -90,7 +91,7 @@ class Exception extends \Exception implements ContainerException
      * @return Exception\SetterMethodNotFound
      *
      */
-    static public function setterMethodNotFound($class, $method)
+    static public function setterMethodNotFound(string $class, string $method): Exception\SetterMethodNotFound
     {
         throw new Exception\SetterMethodNotFound("Setter method not found: {$class}::{$method}()");
     }
@@ -104,7 +105,7 @@ class Exception extends \Exception implements ContainerException
      * @return Exception\NoSuchProperty
      *
      */
-    static public function noSuchProperty($name)
+    static public function noSuchProperty(string $name): Exception\NoSuchProperty
     {
         throw new Exception\NoSuchProperty("Property does not exist: \${$name}");
     }

--- a/src/Exception/ContainerLocked.php
+++ b/src/Exception/ContainerLocked.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Exception/MissingParam.php
+++ b/src/Exception/MissingParam.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Exception/NoSuchProperty.php
+++ b/src/Exception/NoSuchProperty.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Exception/ServiceNotFound.php
+++ b/src/Exception/ServiceNotFound.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -9,7 +10,7 @@
 namespace Aura\Di\Exception;
 
 use Aura\Di\Exception;
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  *
@@ -18,6 +19,6 @@ use Interop\Container\Exception\NotFoundException;
  * @package Aura.Di
  *
  */
-class ServiceNotFound extends Exception implements NotFoundException
+class ServiceNotFound extends Exception implements NotFoundExceptionInterface
 {
 }

--- a/src/Exception/ServiceNotObject.php
+++ b/src/Exception/ServiceNotObject.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Exception/SetterMethodNotFound.php
+++ b/src/Exception/SetterMethodNotFound.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Injection/Factory.php
+++ b/src/Injection/Factory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -72,7 +73,7 @@ class Factory
      */
     public function __construct(
         Resolver $resolver,
-        $class,
+        string $class,
         array $params = [],
         array $setters = []
     ) {
@@ -95,7 +96,7 @@ class Factory
      * @return object
      *
      */
-    public function __invoke()
+    public function __invoke(): object
     {
         $params = array_merge($this->params, func_get_args());
         $resolve = $this->resolver->resolve(

--- a/src/Injection/InjectionFactory.php
+++ b/src/Injection/InjectionFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -9,7 +10,7 @@
 namespace Aura\Di\Injection;
 
 use Aura\Di\Resolver\Resolver;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  *
@@ -48,7 +49,7 @@ class InjectionFactory
      * @return Resolver
      *
      */
-    public function getResolver()
+    public function getResolver(): Resolver
     {
         return $this->resolver;
     }
@@ -63,14 +64,15 @@ class InjectionFactory
      *
      * @param array $setters Setters for the instantiation.
      *
-     * @return mixed
+     * @return object
      *
      */
     public function newInstance(
         $class,
         array $params = [],
         array $setters = []
-    ) {
+    ): object
+    {
         $resolve = $this->resolver->resolve($class, $params, $setters);
 
         $expandedParams = $this->resolver->getExpandedParams($class, $resolve->params);
@@ -99,7 +101,8 @@ class InjectionFactory
         $class,
         array $params = [],
         array $setters = []
-    ) {
+    ): Factory
+    {
         return new Factory($this->resolver, $class, $params, $setters);
     }
 
@@ -114,7 +117,7 @@ class InjectionFactory
      * @return Lazy
      *
      */
-    public function newLazy($callable, array $params = [])
+    public function newLazy($callable, array $params = []): Lazy
     {
         return new Lazy($callable, $params);
     }
@@ -128,7 +131,7 @@ class InjectionFactory
      * @return LazyArray
      *
      */
-    public function newLazyArray(array $callables)
+    public function newLazyArray(array $callables): LazyArray
     {
         return new LazyArray($callables);
     }
@@ -142,7 +145,7 @@ class InjectionFactory
      * @return LazyCallable
      *
      */
-    public function newLazyCallable($callable)
+    public function newLazyCallable($callable): LazyCallable
     {
         return new LazyCallable($callable);
     }
@@ -158,7 +161,7 @@ class InjectionFactory
      * @return LazyGet
      *
      */
-    public function newLazyGet(ContainerInterface $container, $service)
+    public function newLazyGet(ContainerInterface $container, string $service): LazyGet
     {
         return new LazyGet($container, $service);
     }
@@ -172,7 +175,7 @@ class InjectionFactory
      * @return LazyInclude
      *
      */
-    public function newLazyInclude($file)
+    public function newLazyInclude(string $file): LazyInclude
     {
         return new LazyInclude($file);
     }
@@ -187,14 +190,15 @@ class InjectionFactory
      *
      * @param array $setters Setters for the instantiation.
      *
-     * @return Lazy
+     * @return LazyNew
      *
      */
     public function newLazyNew(
-        $class,
+        string $class,
         array $params = [],
         array $setters = []
-    ) {
+    ): LazyNew
+    {
         return new LazyNew($this->resolver, $class, $params, $setters);
     }
 
@@ -207,7 +211,7 @@ class InjectionFactory
      * @return LazyRequire
      *
      */
-    public function newLazyRequire($file)
+    public function newLazyRequire(string $file): LazyRequire
     {
         return new LazyRequire($file);
     }
@@ -221,7 +225,7 @@ class InjectionFactory
      * @return LazyValue
      *
      */
-    public function newLazyValue($key)
+    public function newLazyValue(string $key): LazyValue
     {
         return new LazyValue($this->resolver, $key);
     }

--- a/src/Injection/Lazy.php
+++ b/src/Injection/Lazy.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Injection/LazyArray.php
+++ b/src/Injection/LazyArray.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Injection/LazyCallable.php
+++ b/src/Injection/LazyCallable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Injection/LazyGet.php
+++ b/src/Injection/LazyGet.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -8,8 +9,7 @@
  */
 namespace Aura\Di\Injection;
 
-use Aura\Di\Container;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  *
@@ -60,7 +60,7 @@ class LazyGet implements LazyInterface
      * @return object The object created by the closure.
      *
      */
-    public function __invoke()
+    public function __invoke(): object
     {
         return $this->container->get($this->service);
     }

--- a/src/Injection/LazyInclude.php
+++ b/src/Injection/LazyInclude.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -33,7 +34,7 @@ class LazyInclude implements LazyInterface
      * @param string|LazyInterface $file The file to include.
      *
      */
-    public function __construct($file)
+    public function __construct(string $file)
     {
         $this->file = $file;
     }
@@ -47,10 +48,6 @@ class LazyInclude implements LazyInterface
      */
     public function __invoke()
     {
-        $filename = $this->file;
-        if ($filename instanceof LazyInterface) {
-            $filename = $filename->__invoke();
-        }
-        return include $filename;
+        return include $this->file;
     }
 }

--- a/src/Injection/LazyInterface.php
+++ b/src/Injection/LazyInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Injection/LazyNew.php
+++ b/src/Injection/LazyNew.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Injection/LazyRequire.php
+++ b/src/Injection/LazyRequire.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -33,7 +34,7 @@ class LazyRequire implements LazyInterface
      * @param string|LazyInterface $file The file to require.
      *
      */
-    public function __construct($file)
+    public function __construct(string $file)
     {
         $this->file = $file;
     }
@@ -47,10 +48,6 @@ class LazyRequire implements LazyInterface
      */
     public function __invoke()
     {
-        $filename = $this->file;
-        if ($filename instanceof LazyInterface) {
-            $filename = $filename->__invoke();
-        }
-        return require $filename;
+        return require $this->file;
     }
 }

--- a/src/Injection/LazyValue.php
+++ b/src/Injection/LazyValue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -46,7 +47,7 @@ class LazyValue implements LazyInterface
      * @param string $key The value key to retrieve.
      *
      */
-    public function __construct(Resolver $resolver, $key)
+    public function __construct(Resolver $resolver, string $key)
     {
         $this->resolver = $resolver;
         $this->key = $key;

--- a/src/ResolutionHelper.php
+++ b/src/ResolutionHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.

--- a/src/Resolver/AutoResolver.php
+++ b/src/Resolver/AutoResolver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -44,7 +45,7 @@ class AutoResolver extends Resolver
      * @return mixed The auto-resolved param value, or UnresolvedParam.
      *
      */
-    protected function getUnifiedParam(ReflectionParameter $rparam, $class, $parent)
+    protected function getUnifiedParam(ReflectionParameter $rparam, string $class, array $parent)
     {
         $unified = parent::getUnifiedParam($rparam, $class, $parent);
 

--- a/src/Resolver/Reflector.php
+++ b/src/Resolver/Reflector.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -8,7 +9,6 @@
  */
 namespace Aura\Di\Resolver;
 
-use Aura\Di\Exception;
 use ReflectionClass;
 use ReflectionException;
 
@@ -55,7 +55,7 @@ class Reflector
      * @return array
      *
      */
-    public function __sleep()
+    public function __sleep(): array
     {
         return ['traits'];
     }
@@ -71,7 +71,7 @@ class Reflector
      * @throws ReflectionException when the class does not exist.
      *
      */
-    public function getClass($class)
+    public function getClass($class): ReflectionClass
     {
         if (! isset($this->classes[$class])) {
             $this->classes[$class] = new ReflectionClass($class);
@@ -88,10 +88,10 @@ class Reflector
      * @param string $class Return the array of ReflectionParameter instances
      * for the constructor of this class.
      *
-     * @return array
+     * @return array|\ReflectionParameter[]
      *
      */
-    public function getParams($class)
+    public function getParams($class): array
     {
         if (! isset($this->params[$class])) {
             $this->params[$class] = [];
@@ -118,7 +118,7 @@ class Reflector
      * in the parent keys.
      *
      */
-    public function getTraits($class)
+    public function getTraits($class): array
     {
         if (! isset($this->traits[$class])) {
             $traits = [];

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -25,6 +26,15 @@ class Resolver
 {
     /**
      *
+     * A Reflector.
+     *
+     * @var Reflector
+     *
+     */
+    protected $reflector;
+
+    /**
+     *
      * Constructor params in the form `$params[$class][$name] = $value`.
      *
      * @var array
@@ -49,15 +59,6 @@ class Resolver
      *
      */
     protected $values = [];
-
-    /**
-     *
-     * A Reflector.
-     *
-     * @var Reflector
-     *
-     */
-    protected $reflector = [];
 
     /**
      *
@@ -92,7 +93,7 @@ class Resolver
      * @throws Exception\NoSuchProperty
      *
      */
-    public function &__get($key)
+    public function &__get($key): array
     {
         if (isset($this->$key)) {
             return $this->$key;
@@ -125,7 +126,8 @@ class Resolver
         $class,
         array $mergeParams = [],
         array $mergeSetters = []
-    ) {
+    ): object
+    {
         list($params, $setters) = $this->getUnified($class);
         $this->mergeParams($class, $params, $mergeParams);
         $this->mergeSetters($class, $setters, $mergeSetters);
@@ -146,10 +148,8 @@ class Resolver
      *
      * @param array $mergeSetters Override with these setters.
      *
-     * @return null
-     *
      */
-    protected function mergeSetters($class, &$setters, array $mergeSetters = [])
+    protected function mergeSetters($class, &$setters, array $mergeSetters = []): void
     {
         $setters = array_merge($setters, $mergeSetters);
         foreach ($setters as $method => $value) {
@@ -174,12 +174,10 @@ class Resolver
      * be the name *or* the numeric position of the constructor parameter, and
      * the value is the parameter value to use.
      *
-     * @return array
-     *
      * @throws \Aura\Di\Exception\MissingParam if a constructor param is missing.
      *
      */
-    protected function mergeParams($class, &$params, array $mergeParams = [])
+    protected function mergeParams($class, &$params, array $mergeParams = []): void
     {
         if (! $mergeParams) {
             // no params to merge, micro-optimize the loop
@@ -225,12 +223,10 @@ class Resolver
      *
      * @param array $params The constructor parameters.
      *
-     * @return null
-     *
      * @throws \Aura\Di\Exception\MissingParam if a constructor param is missing.
      *
      */
-    protected function mergeParamsEmpty($class, &$params)
+    protected function mergeParamsEmpty(string $class, array &$params): void
     {
         foreach ($params as $key => $val) {
             // is the param missing?
@@ -254,7 +250,7 @@ class Resolver
      * for the class, and 1 is the setter methods and values for the class.
      *
      */
-    public function getUnified($class)
+    public function getUnified(string $class): array
     {
         // have values already been unified for this class?
         if (isset($this->unified[$class])) {
@@ -290,7 +286,7 @@ class Resolver
      * @return array The unified params.
      *
      */
-    protected function getUnifiedParams($class, array $parent)
+    protected function getUnifiedParams(string $class, array $parent): array
     {
         // reflect on what params to pass, in which order
         $unified = [];
@@ -303,7 +299,6 @@ class Resolver
             );
         }
 
-        // done
         return $unified;
     }
 
@@ -320,7 +315,7 @@ class Resolver
      * @return mixed The unified param value.
      *
      */
-    protected function getUnifiedParam(ReflectionParameter $rparam, $class, $parent)
+    protected function getUnifiedParam(ReflectionParameter $rparam, string $class, array $parent)
     {
         $name = $rparam->getName();
         $pos = $rparam->getPosition();
@@ -373,7 +368,7 @@ class Resolver
      * @return array The unified setters.
      *
      */
-    protected function getUnifiedSetters($class, array $parent)
+    protected function getUnifiedSetters(string $class, array $parent): array
     {
         $unified = $parent;
 
@@ -407,26 +402,20 @@ class Resolver
             );
         }
 
-        // done
         return $unified;
     }
 
     /**
      * Expands variadic parameters onto the end of a contructor parameters array.
      *
-     * @param type $class The class name to expand parameters for.
+     * @param string $class The class name to expand parameters for.
      *
      * @param array $params An array of constructor parameters and values.
      *
      * @return array The expanded constructor parameters.
      */
-    public function getExpandedParams($class, array $params)
+    public function getExpandedParams(string $class, array $params): array
     {
-        // Variadics are only available in PHP >= 5.6, and not in HHVM
-        if (version_compare(PHP_VERSION, '5.6') === -1 || defined('HHVM_VERSION')) {
-            return $params;
-        }
-
         $variadicParams = [];
         foreach ($this->reflector->getParams($class) as $reflectParam) {
             $paramName = $reflectParam->getName();

--- a/src/Resolver/UnresolvedParam.php
+++ b/src/Resolver/UnresolvedParam.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -33,7 +34,7 @@ class UnresolvedParam
      * @param string $name The name of the missing param.
      *
      */
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
@@ -42,12 +43,10 @@ class UnresolvedParam
      *
      * Returns the name of the missing param.
      *
-     * @param string $class Prefix the param name with this class name.
-     *
      * @return string
      *
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/tests/AbstractContainerConfigTest.php
+++ b/tests/AbstractContainerConfigTest.php
@@ -8,7 +8,7 @@
  */
 namespace Aura\Di;
 
-use Aura\Di\ContainerBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  *
@@ -18,7 +18,7 @@ use Aura\Di\ContainerBuilder;
  * @package Aura.Di
  *
  */
-abstract class AbstractContainerConfigTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractContainerConfigTest extends TestCase
 {
     /**
      *

--- a/tests/ContainerBuilderTest.php
+++ b/tests/ContainerBuilderTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Aura\Di;
 
-class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ContainerBuilderTest extends TestCase
 {
     protected $builder;
 
@@ -61,14 +63,14 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalid()
     {
-        $this->setExpectedException('InvalidArgumentException');
-        $di = $this->builder->newConfiguredInstance([[]]);
+        $this->expectException('InvalidArgumentException');
+        $this->builder->newConfiguredInstance([[]]);
     }
 
     public function testInvalidDuckType()
     {
-        $this->setExpectedException('InvalidArgumentException');
-        $di = $this->builder->newConfiguredInstance([(object) []]);
+        $this->expectException('InvalidArgumentException');
+        $this->builder->newConfiguredInstance([(object) []]);
     }
 
     public function testSerializeAndUnserialize()

--- a/tests/Fake/FakeLibraryConfig.php
+++ b/tests/Fake/FakeLibraryConfig.php
@@ -6,13 +6,13 @@ use Aura\Di\ContainerConfig;
 
 class FakeLibraryConfig extends ContainerConfig
 {
-    public function define(Container $di)
+    public function define(Container $di): void
     {
         parent::define($di);
         $di->set('library_service', (object) ['foo' => 'bar']);
     }
 
-    public function modify(Container $di)
+    public function modify(Container $di): void
     {
         parent::modify($di);
         $di->get('library_service')->foo = 'zim';

--- a/tests/Fake/FakeProjectConfig.php
+++ b/tests/Fake/FakeProjectConfig.php
@@ -6,13 +6,13 @@ use Aura\Di\ContainerConfig;
 
 class FakeProjectConfig extends ContainerConfig
 {
-    public function define(Container $di)
+    public function define(Container $di): void
     {
         parent::define($di);
         $di->set('project_service', (object) ['baz' => 'dib']);
     }
 
-    public function modify(Container $di)
+    public function modify(Container $di): void
     {
         parent::modify($di);
         $di->get('project_service')->baz = 'gir';

--- a/tests/Injection/FactoryTest.php
+++ b/tests/Injection/FactoryTest.php
@@ -3,8 +3,9 @@ namespace Aura\Di\Injection;
 
 use Aura\Di\Resolver\Resolver;
 use Aura\Di\Resolver\Reflector;
+use PHPUnit\Framework\TestCase;
 
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     protected $resolver;
 

--- a/tests/Injection/LazyIncludeTest.php
+++ b/tests/Injection/LazyIncludeTest.php
@@ -1,16 +1,14 @@
 <?php
 namespace Aura\Di\Injection;
 
-class LazyIncludeTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class LazyIncludeTest extends TestCase
 {
     public function test__invoke()
     {
         $file = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'lazy_array.php';
-        $lazyValueStub = $this->getMockBuilder('Aura\Di\Injection\LazyInterface')
-            ->getMock();
-        $lazyValueStub->method('__invoke')
-             ->willReturn($file);
-        $lazyInclude = new LazyInclude($lazyValueStub);
+        $lazyInclude = new LazyInclude($file);
         $actual = $lazyInclude->__invoke();
         $expected = ['foo' => 'bar'];
         $this->assertSame($expected, $actual);

--- a/tests/Injection/LazyRequireTest.php
+++ b/tests/Injection/LazyRequireTest.php
@@ -1,16 +1,14 @@
 <?php
 namespace Aura\Di\Injection;
 
-class LazyRequireTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class LazyRequireTest extends TestCase
 {
     public function test__invoke()
     {
         $file = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'lazy_array.php';
-        $lazyValueStub = $this->getMockBuilder('Aura\Di\Injection\LazyInterface')
-            ->getMock();
-        $lazyValueStub->method('__invoke')
-             ->willReturn($file);
-        $lazyInclude = new LazyRequire($lazyValueStub);
+        $lazyInclude = new LazyRequire($file);
         $actual = $lazyInclude->__invoke();
         $expected = ['foo' => 'bar'];
         $this->assertSame($expected, $actual);

--- a/tests/MinimalContainer.php
+++ b/tests/MinimalContainer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Aura\Di;
+
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+class MinimalContainer implements ContainerInterface
+{
+    private $collection = [];
+    private $delegateContainer;
+
+    public function __construct(array $services, ContainerInterface $delegateContainer = null)
+    {
+        $this->collection = $services;
+        $this->delegateContainer = $delegateContainer;
+    }
+
+    public function get($id)
+    {
+        if (isset($this->collection[$id])) {
+            if (is_callable($this->collection[$id])) {
+                $this->collection[$id] = call_user_func($this->collection[$id], $this);
+            }
+
+            return $this->collection[$id];
+        }
+
+        if ($this->delegateContainer && $this->delegateContainer->has($id)) {
+            return $this->delegateContainer->get($id);
+        }
+
+        throw new class extends \UnexpectedValueException implements NotFoundExceptionInterface {};
+    }
+
+    public function has($id)
+    {
+        return isset($this->collection[$id]);
+    }
+}

--- a/tests/ResolutionHelperTest.php
+++ b/tests/ResolutionHelperTest.php
@@ -1,9 +1,9 @@
 <?php
 namespace Aura\Di;
 
-use Aura\Di\ResolutionHelper;
+use PHPUnit\Framework\TestCase;
 
-class ResolutionHelperTest extends \PHPUnit_Framework_TestCase
+class ResolutionHelperTest extends TestCase
 {
     protected $container;
 
@@ -60,7 +60,7 @@ class ResolutionHelperTest extends \PHPUnit_Framework_TestCase
     public function testResolveStringService()
     {
         $spec   = 'foo';
-        $expect = 'return';
+        $expect = new \stdClass();
 
         $this->containerHas($spec, $expect);
 
@@ -72,7 +72,7 @@ class ResolutionHelperTest extends \PHPUnit_Framework_TestCase
     public function testResolveStringInstance()
     {
         $spec   = 'foo';
-        $expect = 'return';
+        $expect = new \stdClass();
 
         $this->containerDoesNotHave($spec, $expect);
 
@@ -86,7 +86,7 @@ class ResolutionHelperTest extends \PHPUnit_Framework_TestCase
     {
         $class  = 'foo';
         $spec   = [$class, 'bar'];
-        $return = 'return';
+        $return = new \stdClass();
         $expect = [$return, 'bar'];
 
         $this->containerHas($class, $return);
@@ -100,7 +100,7 @@ class ResolutionHelperTest extends \PHPUnit_Framework_TestCase
     {
         $class  = 'foo';
         $spec   = [$class, 'bar'];
-        $return = 'return';
+        $return = new \stdClass();
         $expect = [$return, 'bar'];
 
         $this->containerDoesNotHave($class, $return);

--- a/tests/Resolver/AutoResolverTest.php
+++ b/tests/Resolver/AutoResolverTest.php
@@ -28,7 +28,7 @@ class AutoResolverTest extends ResolverTest
 
     public function testAutoResolveMissingParam()
     {
-        $this->setExpectedException('Aura\Di\Exception\MissingParam');
-        $actual = $this->resolver->resolve('Aura\Di\Fake\FakeParamsClass');
+        $this->expectException('Aura\Di\Exception\MissingParam');
+        $this->resolver->resolve('Aura\Di\Fake\FakeParamsClass');
     }
 }

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -2,8 +2,9 @@
 namespace Aura\Di\Resolver;
 
 use Aura\Di\Injection\Lazy;
+use PHPUnit\Framework\TestCase;
 
-class ResolverTest extends \PHPUnit_Framework_TestCase
+class ResolverTest extends TestCase
 {
     protected $resolver;
 
@@ -16,7 +17,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     public function testReadsConstructorDefaults()
     {
         $expect = ['foo' => 'bar'];
-        list($actual_params, $actual_setter) = $this->resolver->getUnified('Aura\Di\Fake\FakeParentClass');
+        [$actual_params, ] = $this->resolver->getUnified('Aura\Di\Fake\FakeParentClass');
         $this->assertSame($expect, $actual_params);
     }
 
@@ -34,7 +35,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
             'zim' => null,
         ];
 
-        list($actual_params, $actual_setter) = $this->resolver->getUnified('Aura\Di\Fake\FakeChildClass');
+        [$actual_params, ] = $this->resolver->getUnified('Aura\Di\Fake\FakeChildClass');
         $this->assertSame($expect, $actual_params);
     }
 
@@ -43,7 +44,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->params['Aura\Di\Fake\FakeParentClass'] = ['foo' => 'zim'];
 
         $expect = ['foo' => 'zim'];
-        list($actual_params, $actual_setter) = $this->resolver->getUnified('Aura\Di\Fake\FakeParentClass');
+        [$actual_params, ] = $this->resolver->getUnified('Aura\Di\Fake\FakeParentClass');
         $this->assertSame($expect, $actual_params);
     }
 
@@ -56,7 +57,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
             'zim' => null,
         ];
 
-        list($actual_params, $actual_setter) = $this->resolver->getUnified('Aura\Di\Fake\FakeChildClass');
+        [$actual_params, ] = $this->resolver->getUnified('Aura\Di\Fake\FakeChildClass');
         $this->assertSame($expect, $actual_params);
 
         // for test coverage of the mock class
@@ -67,7 +68,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     {
         $this->resolver->setters['Aura\Di\Fake\FakeParentClass']['setFake'] = 'fake1';
 
-        list($actual_config, $actual_setter) = $this->resolver->getUnified('Aura\Di\Fake\FakeChildClass');
+        [, $actual_setter] = $this->resolver->getUnified('Aura\Di\Fake\FakeChildClass');
         $expect = ['setFake' => 'fake1'];
         $this->assertSame($expect, $actual_setter);
 
@@ -78,7 +79,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->setters['Aura\Di\Fake\FakeParentClass']['setFake'] = 'fake1';
         $this->resolver->setters['Aura\Di\Fake\FakeChildClass']['setFake'] = 'fake2';
 
-        list($actual_config, $actual_setter) = $this->resolver->getUnified('Aura\Di\Fake\FakeChildClass');
+        [, $actual_setter] = $this->resolver->getUnified('Aura\Di\Fake\FakeChildClass');
         $expect = ['setFake' => 'fake2'];
         $this->assertSame($expect, $actual_setter);
     }
@@ -87,7 +88,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     {
         $this->resolver->setters['Aura\Di\Fake\FakeTrait']['setFake'] = 'fake1';
 
-        list($actual_config, $actual_setter) = $this->resolver->getUnified('Aura\Di\Fake\FakeClassWithTrait');
+        [, $actual_setter] = $this->resolver->getUnified('Aura\Di\Fake\FakeClassWithTrait');
         $expect = ['setFake' => 'fake1'];
         $this->assertSame($expect, $actual_setter);
     }
@@ -96,7 +97,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     {
         $this->resolver->setters['Aura\Di\Fake\FakeChildTrait']['setChildFake'] = 'fake1';
 
-        list($actual_config, $actual_setter) = $this->resolver->getUnified('Aura\Di\Fake\FakeClassWithTrait');
+        [, $actual_setter] = $this->resolver->getUnified('Aura\Di\Fake\FakeClassWithTrait');
         $expect = ['setChildFake' => 'fake1'];
         $this->assertSame($expect, $actual_setter);
     }
@@ -105,9 +106,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     {
         $this->resolver->setters['Aura\Di\Fake\FakeGrandchildTrait']['setGrandchildFake'] = 'fake1';
 
-        list($actual_config, $actual_setter) = $this->resolver->getUnified(
-            'Aura\Di\Fake\FakeClassWithTrait'
-        );
+        [, $actual_setter] = $this->resolver->getUnified('Aura\Di\Fake\FakeClassWithTrait');
         $expect = ['setGrandchildFake' => 'fake1'];
         $this->assertSame($expect, $actual_setter);
     }
@@ -115,9 +114,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     public function testHonorsParentClassTraits()
     {
         $this->resolver->setters['Aura\Di\Fake\FakeGrandchildTrait']['setGrandchildFake'] = 'fake1';
-        list($actual_config, $actual_setter) = $this->resolver->getUnified(
-            'Aura\Di\Fake\FakeClassWithParentTrait'
-        );
+        [, $actual_setter] = $this->resolver->getUnified('Aura\Di\Fake\FakeClassWithParentTrait');
         $expect = ['setGrandchildFake' => 'fake1'];
         $this->assertSame($expect, $actual_setter);
     }
@@ -129,14 +126,14 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->setters['Aura\Di\Fake\FakeClassWithTrait']['setFake'] = 'fake3';
         $this->resolver->setters['Aura\Di\Fake\FakeClassWithTrait']['setChildFake'] = 'fake4';
 
-        list($actual_config, $actual_setter) = $this->resolver->getUnified('Aura\Di\Fake\FakeClassWithTrait');
+        [, $actual_setter] = $this->resolver->getUnified('Aura\Di\Fake\FakeClassWithTrait');
         $expect = ['setChildFake' => 'fake4', 'setFake' => 'fake3'];
         $this->assertSame($expect, $actual_setter);
     }
 
     public function testReflectionOnMissingClass()
     {
-        $this->setExpectedException('ReflectionException');
+        $this->expectException('ReflectionException');
         $this->resolver->resolve('NoSuchClass');
     }
 
@@ -151,16 +148,14 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testMissingParam()
     {
-        $this->setExpectedException(
-            'Aura\Di\Exception\MissingParam',
-            'Aura\Di\Fake\FakeResolveClass::$fake'
-        );
+        $this->expectException('Aura\Di\Exception\MissingParam');
+        $this->expectExceptionMessage('Aura\Di\Fake\FakeResolveClass::$fake');
         $this->resolver->resolve('Aura\Di\Fake\FakeResolveClass');
     }
 
     public function testUnresolvedParamAfterMergeParams()
     {
-        $this->setExpectedException('Aura\Di\Exception\MissingParam');
+        $this->expectException('Aura\Di\Exception\MissingParam');
         $this->resolver->resolve('Aura\Di\Fake\FakeParamsClass', [
             'noSuchParam' => 'foo'
         ]);


### PR DESCRIPTION
- Upgrade to PHP 7.2+ only, strict types enabled
- Dropped HHVM support
- PHPUnit now @ ^7
- Signatures of methods in ContainerConfigInterface changed.
- LazyRequire and LazyInclude do not accept another lazy
- Remove container interop dependency
- Fixes #161, #163, #171 and #166 