### PR TITLE
Feature: mutations

### DIFF
--- a/docs/_bookdown.json
+++ b/docs/_bookdown.json
@@ -4,6 +4,7 @@
         "getting-started.md",
         "constructor.md",
         "setter.md",
+        "mutations.md",
         "inheritance.md",
         "services.md",
         "lazy.md",

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -1,7 +1,7 @@
 # Mutate object after instantion
 
 The _Container_ supports objects to be mutated after it is constructed. This is especially useful when you have separate
-container configs that both need to modify the object that will be constructed. Use cases could be adding routes to a
+container configs that both need to define the object that will be constructed. Use cases could be adding routes to a
 router from multiple configs or adding commands to a console application object.
 
 After the _Container_ constructs a new instance of an object, you can specify which other objects will mutate the 

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -1,0 +1,48 @@
+# Mutate object after instantion
+
+The _Container_ supports objects to be mutated after it is constructed.
+
+After the _Container_ constructs a new instance of an object, you can specify which other objects will mutate the original object before locking it.
+
+Say we have classes like the following:
+
+```php
+namespace Vendor\Package;
+
+use Aura\Di\Injection\MutationInterface;
+
+class Example
+{
+    protected $foo;
+
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+}
+
+class ExampleMutation implements MutationInterface
+{
+    public function mutate(object $object): object
+    {
+        $object->setFoo('mutated');
+        return $object;
+    }
+}
+```
+
+We can specify that it should be mutated after construction like so:
+
+```php
+$di->mutations['Vendor\Package\Example'][] = new ExampleMutation();
+```
+
+Or lazy, like so.
+
+```php
+$di->mutations['Vendor\Package\Example'][] = $di->lazyNew(ExampleMutation::class);
+```
+
+This also allows you to create new instances of immutable objects.
+
+> N.b.: If you try to access `$mutations` after calling `newInstance()` (or after locking the _Container_ using the `lock()` method) the _Container_ will throw an exception. This is to prevent modifying the params after objects have been created. Thus, be sure to set up all mutations for all objects before creating an object.

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -80,6 +80,4 @@ class RegisterRoutesMutation implements MutationInterface
 }
 ```
  
-This also allows you to create new instances of immutable objects.
-
 > N.b.: If you try to access `$di->mutations` after calling `newInstance()` (or after locking the _Container_ using the `lock()` method) the _Container_ will throw an exception. This is to prevent modifying the params after objects have been created. Thus, be sure to set up all mutations for all objects before creating an object.

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -5,7 +5,7 @@ container configs that both need to define the object that will be constructed. 
 router from multiple configs or adding commands to a console application object.
 
 After the _Container_ constructs a new instance of an object, you can specify which other objects will mutate the 
-original object before locking it.
+original object before locking the container.
 
 Say we have classes like the following:
 

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -43,6 +43,14 @@ Or lazy, like so.
 $di->mutations['Vendor\Package\Example'][] = $di->lazyNew(ExampleMutation::class);
 ```
 
+Just like with any other class, you inject params to the mutation class.
+
+```php
+$di->params[ExampleMutation::class]['argX'] = $di->lazyGet('service');
+$di->params[ExampleMutation::class]['argY'] = $di;
+$di->mutations['Vendor\Package\Example'][] = $di->lazyNew(ExampleMutation::class);
+```
+
 This also allows you to create new instances of immutable objects.
 
 > N.b.: If you try to access `$mutations` after calling `newInstance()` (or after locking the _Container_ using the `lock()` method) the _Container_ will throw an exception. This is to prevent modifying the params after objects have been created. Thus, be sure to set up all mutations for all objects before creating an object.

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -44,6 +44,23 @@ $di->mutations['Vendor\Package\Example'][] = $di->lazyNew(ExampleMutation::class
 Just like with any other class, you inject params to the mutation class.
 
 ```php
+class ExampleMutation implements MutationInterface
+{
+    private $argX, $argxY;
+    
+    public function __construct ($argX, $argY) {
+        $this->argX = $argX;
+        $this->argY = $argy;
+    }
+    
+    public function __invoke(object $object): object
+    {
+        $object->setFoo($this->argX);
+        $object->setBaz($this->argY);
+        return $object;
+    }
+}
+
 $di->params[ExampleMutation::class]['argX'] = $di->lazyGet('service');
 $di->params[ExampleMutation::class]['argY'] = $di;
 $di->mutations['Vendor\Package\Example'][] = $di->lazyNew(ExampleMutation::class);

--- a/docs/setter.md
+++ b/docs/setter.md
@@ -26,6 +26,6 @@ We can specify that, by default, the `setFoo()` method should be called with a s
 $di->setters['Vendor\Package\Example']['setFoo'] = 'foo_value';
 ```
 
-Note also that this works only with explicitly-defined setter methods. Setter methods that exist only via magic `__call()` will not be honored.
+Note also that this works only with explicitly-defined setter methods. Setter methods that exist only via magic `__call()` will not be honored. Use _mutations_ if you want to call magic methods. 
 
 > N.b.: If you try to access `$setters` after calling `newInstance()` (or after locking the _Container_ using the `lock()` method) the _Container_ will throw an exception. This is to prevent modifying the params after objects have been created. Thus, be sure to set up all params for all objects before creating an object.

--- a/src/Container.php
+++ b/src/Container.php
@@ -33,6 +33,8 @@ use Psr\Container\ContainerInterface;
  *
  * @property array $setters A reference to the Resolver $setters.
  *
+ * @property array $mutations A reference to the Resolver $mutates.
+ *
  * @property array $types A reference to the Resolver $types.
  *
  * @property array $values A reference to the Resolver $values.

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -98,6 +98,26 @@ class Exception extends \Exception implements ContainerExceptionInterface
 
     /**
      *
+     * A mutation was lazy and returned a value that is not an instanceof MutationInterface.
+     *
+     * @param mixed $value The returned value.
+     *
+     * @return Exception\SetterMethodNotFound
+     *
+     */
+    static public function mutationDoesNotImplementInterface($value): Exception\SetterMethodNotFound
+    {
+        if (\is_object($value)) {
+            $className = get_class($value);
+            throw new Exception\MutationDoesNotImplementInterface("Mutation does not implement interface: {$className}");
+        }
+
+        $typeName = \gettype($value);
+        throw new Exception\MutationDoesNotImplementInterface("Expected Mutation interface, got: {$typeName}");
+    }
+
+    /**
+     *
      * A requested property does not exist.
      *
      * @param string $name The property name.

--- a/src/Exception/MutationDoesNotImplementInterface.php
+++ b/src/Exception/MutationDoesNotImplementInterface.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+namespace Aura\Di\Exception;
+
+use Aura\Di\Exception;
+
+/**
+ *
+ * Setter method not found in target class.
+ *
+ * @package Aura.Di
+ *
+ */
+class MutationDoesNotImplementInterface extends Exception
+{
+}

--- a/src/Injection/Factory.php
+++ b/src/Injection/Factory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  */
 namespace Aura\Di\Injection;
 
+use Aura\Di\Exception;
 use Aura\Di\Resolver\Resolver;
 
 /**
@@ -111,6 +112,20 @@ class Factory
         foreach ($resolve->setters as $method => $value) {
             $object->$method($value);
         }
+
+        /** @var MutationInterface $mutation */
+        foreach ($resolve->mutations as $mutation) {
+            if ($mutation instanceof LazyInterface) {
+                $mutation = $mutation();
+            }
+
+            if ($mutation instanceof MutationInterface === false) {
+                throw Exception::mutationDoesNotImplementInterface($mutation);
+            }
+
+            $object = $mutation($object);
+        }
+
         return $object;
     }
 }

--- a/src/Injection/InjectionFactory.php
+++ b/src/Injection/InjectionFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  */
 namespace Aura\Di\Injection;
 
+use Aura\Di\Exception;
 use Aura\Di\Resolver\Resolver;
 use Psr\Container\ContainerInterface;
 
@@ -81,6 +82,20 @@ class InjectionFactory
         foreach ($resolve->setters as $method => $value) {
             $object->$method($value);
         }
+
+        /** @var MutationInterface $mutation */
+        foreach ($resolve->mutations as $mutation) {
+            if ($mutation instanceof LazyInterface) {
+                $mutation = $mutation();
+            }
+
+            if ($mutation instanceof MutationInterface === false) {
+                throw Exception::mutationDoesNotImplementInterface($mutation);
+            }
+
+            $object = $mutation($object);
+        }
+
         return $object;
     }
 

--- a/src/Injection/MutationInterface.php
+++ b/src/Injection/MutationInterface.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+namespace Aura\Di\Injection;
+
+/**
+ *
+ * Indicates a Mutation to be invoked after constructing an object
+ *
+ * @package Aura.Di
+ *
+ */
+interface MutationInterface
+{
+    /**
+     *
+     * Invokes the Mutation to return an object.
+     *
+     * @param object $object
+     *
+     * @return object
+     */
+    public function __invoke(object $object): object;
+}

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -53,6 +53,15 @@ class Resolver
 
     /**
      *
+     * Setter definitions in the form of `$mutations[$class][] = $value`.
+     *
+     * @var array
+     *
+     */
+    protected $mutations = [];
+
+    /**
+     *
      * Arbitrary values in the form of `$values[$key] = $value`.
      *
      * @var array
@@ -117,6 +126,8 @@ class Resolver
      * name of the setter method to call and the value is the value to be
      * passed to the setter method.
      *
+     * @param array $mergeMutations An array of additional mutations.
+     *
      * @return object
      *
      * @throws Exception\SetterMethodNotFound
@@ -125,16 +136,19 @@ class Resolver
     public function resolve(
         $class,
         array $mergeParams = [],
-        array $mergeSetters = []
+        array $mergeSetters = [],
+        array $mergeMutations = []
     ): object
     {
-        list($params, $setters) = $this->getUnified($class);
+        [$params, $setters, $mutations] = $this->getUnified($class);
         $this->mergeParams($class, $params, $mergeParams);
         $this->mergeSetters($class, $setters, $mergeSetters);
+        $this->mergeMutations($mutations, $mergeMutations);
         return (object) [
             'reflection' => $this->reflector->getClass($class),
             'params' => $params,
             'setters' => $setters,
+            'mutations' => $mutations,
         ];
     }
 
@@ -160,6 +174,20 @@ class Resolver
                 $setters[$method] = $value();
             }
         }
+    }
+
+    /**
+     *
+     * Merges the setters with overrides; also invokes Lazy values.
+     *
+     * @param array $mutations The class mutations.
+     *
+     * @param array $mergeMutates Additional mutations.
+     *
+     */
+    protected function mergeMutations(&$mutations, array $mergeMutates = []): void
+    {
+        $mutations = array_merge($mutations, $mergeMutates);
     }
 
     /**
@@ -257,9 +285,9 @@ class Resolver
             return $this->unified[$class];
         }
 
-        // default to an an array of two empty arrays
-        // (one for params, one for setters)
-        $spec = [[], []];
+        // default to an an array of three empty arrays
+        // (one for params, one for setters, one for mutations)
+        $spec = [[], [], []];
 
         // fetch the values for parents so we can inherit them
         $parent = get_parent_class($class);
@@ -270,6 +298,7 @@ class Resolver
         // stores the unified params and setters
         $this->unified[$class][0] = $this->getUnifiedParams($class, $spec[0]);
         $this->unified[$class][1] = $this->getUnifiedSetters($class, $spec[1]);
+        $this->unified[$class][2] = $this->getUnifiedMutations($class, $spec[2]);
 
         // done, return the unified values
         return $this->unified[$class];
@@ -352,6 +381,56 @@ class Resolver
 
         // param is missing
         return new UnresolvedParam($name);
+    }
+
+    /**
+     *
+     * Returns the unified mutations for a class.
+     *
+     * Class-specific mutations are executed last before trait-based mutations and before interface-based mutations.
+     *
+     * @param string $class The class name to return values for.
+     *
+     * @param array $parent The parent unified setters.
+     *
+     * @return array The unified mutations.
+     *
+     */
+    protected function getUnifiedMutations(string $class, array $parent): array
+    {
+        $unified = $parent;
+
+        // look for interface mutations
+        $interfaces = class_implements($class);
+        foreach ($interfaces as $interface) {
+            if (isset($this->mutations[$interface])) {
+                $unified = array_merge(
+                    $this->mutations[$interface],
+                    $unified
+                );
+            }
+        }
+
+        // look for trait mutations
+        $traits = $this->reflector->getTraits($class);
+        foreach ($traits as $trait) {
+            if (isset($this->mutations[$trait])) {
+                $unified = array_merge(
+                    $this->mutations[$trait],
+                    $unified
+                );
+            }
+        }
+
+        // look for class mutations
+        if (isset($this->mutations[$class])) {
+            $unified = array_merge(
+                $unified,
+                $this->mutations[$class]
+            );
+        }
+
+        return $unified;
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2,7 +2,9 @@
 namespace Aura\Di;
 
 use Acclimate\Container\CompositeContainer;
-use Aura\Di\Fake\FakeMutationFakeInterfaceClass;
+use Aura\Di\Fake\FakeMutationClass;
+use Aura\Di\Fake\FakeMutationWithDependencyClass;
+use Aura\Di\Fake\FakeOtherClass;
 use Aura\Di\Fake\FakeParamsClass;
 use Aura\Di\Injection\InjectionFactory;
 use Aura\Di\Resolver\Reflector;
@@ -404,7 +406,7 @@ class ContainerTest extends TestCase
 
     public function testNewInstanceWithMutation()
     {
-        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = new FakeMutationFakeInterfaceClass('mutated');
+        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = new FakeMutationClass('mutated');
 
         $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass');
 
@@ -413,13 +415,24 @@ class ContainerTest extends TestCase
 
     public function testNewInstanceWithLazyMutation()
     {
-        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = $this->container->lazyNew(FakeMutationFakeInterfaceClass::class, [
+        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = $this->container->lazyNew(FakeMutationClass::class, [
             'fooValue' => 'mutated'
         ]);
 
         $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass');
 
         $this->assertSame('mutated', $actual->getFoo());
+    }
+
+    public function testNewInstanceWithLazyMutationInjectContainer()
+    {
+        $this->container->params['Aura\Di\Fake\FakeMutationWithDependencyClass']['container'] = $this->container;
+        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = $this->container->lazyNew(FakeMutationWithDependencyClass::class);
+        $this->container->set('service', $this->container->lazyNew(FakeOtherClass::class));
+
+        $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass');
+
+        $this->assertInstanceOf(FakeOtherClass::class, $actual->getFoo());
     }
 
     public function testHonorsSettersInterfacesAndOverrides()
@@ -446,8 +459,8 @@ class ContainerTest extends TestCase
 
     public function testHonorsMutationInterfacesAndOverrides()
     {
-        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = new FakeMutationFakeInterfaceClass('one');
-        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass2'][] = new FakeMutationFakeInterfaceClass('two');
+        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = new FakeMutationClass('one');
+        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass2'][] = new FakeMutationClass('two');
 
         $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass');
         $this->assertSame('one', $actual->getFoo());

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2,14 +2,19 @@
 namespace Aura\Di;
 
 use Acclimate\Container\CompositeContainer;
+use Aura\Di\Fake\FakeMutationFakeInterfaceClass;
 use Aura\Di\Fake\FakeParamsClass;
 use Aura\Di\Injection\InjectionFactory;
 use Aura\Di\Resolver\Reflector;
 use Aura\Di\Resolver\Resolver;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ContainerTest extends TestCase
 {
+    /**
+     * @var Container|MockObject
+     */
     protected $container;
 
     protected function setUp()
@@ -397,7 +402,27 @@ class ContainerTest extends TestCase
         $this->assertSame('fake_value', $actual->getFake());
     }
 
-    public function testHonorsInterfacesAndOverrides()
+    public function testNewInstanceWithMutation()
+    {
+        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = new FakeMutationFakeInterfaceClass('mutated');
+
+        $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass');
+
+        $this->assertSame('mutated', $actual->getFoo());
+    }
+
+    public function testNewInstanceWithLazyMutation()
+    {
+        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = $this->container->lazyNew(FakeMutationFakeInterfaceClass::class, [
+            'fooValue' => 'mutated'
+        ]);
+
+        $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass');
+
+        $this->assertSame('mutated', $actual->getFoo());
+    }
+
+    public function testHonorsSettersInterfacesAndOverrides()
     {
         $this->container->setters['Aura\Di\Fake\FakeInterface']['setFoo'] = 'initial';
         $this->container->setters['Aura\Di\Fake\FakeInterfaceClass2']['setFoo'] = 'override';
@@ -417,6 +442,24 @@ class ContainerTest extends TestCase
         // uses the "inherited" overridde value
         $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass3');
         $this->assertSame('override', $actual->getFoo());
+    }
+
+    public function testHonorsMutationInterfacesAndOverrides()
+    {
+        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass'][] = new FakeMutationFakeInterfaceClass('one');
+        $this->container->mutations['Aura\Di\Fake\FakeInterfaceClass2'][] = new FakeMutationFakeInterfaceClass('two');
+
+        $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass');
+        $this->assertSame('one', $actual->getFoo());
+
+        $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass1');
+        $this->assertSame('one', $actual->getFoo());
+
+        $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass2');
+        $this->assertSame('two', $actual->getFoo());
+
+        $actual = $this->container->newInstance('Aura\Di\Fake\FakeInterfaceClass3');
+        $this->assertSame('two', $actual->getFoo());
     }
 
     public function testNewInstanceWithLazySetter()

--- a/tests/Fake/FakeMutationClass.php
+++ b/tests/Fake/FakeMutationClass.php
@@ -3,7 +3,7 @@ namespace Aura\Di\Fake;
 
 use Aura\Di\Injection\MutationInterface;
 
-class FakeMutationFakeInterfaceClass implements MutationInterface
+class FakeMutationClass implements MutationInterface
 {
     private $fooValue;
 

--- a/tests/Fake/FakeMutationFakeInterfaceClass.php
+++ b/tests/Fake/FakeMutationFakeInterfaceClass.php
@@ -1,0 +1,28 @@
+<?php
+namespace Aura\Di\Fake;
+
+use Aura\Di\Injection\MutationInterface;
+
+class FakeMutationFakeInterfaceClass implements MutationInterface
+{
+    private $fooValue;
+
+    public function __construct($fooValue)
+    {
+        $this->fooValue = $fooValue;
+    }
+
+    /**
+     *
+     * Invokes the Mutation to return an object.
+     *
+     * @param object|FakeInterfaceClass $object
+     *
+     * @return object
+     */
+    public function __invoke(object $object): object
+    {
+        $object->setFoo($this->fooValue);
+        return $object;
+    }
+}

--- a/tests/Fake/FakeMutationWithDependencyClass.php
+++ b/tests/Fake/FakeMutationWithDependencyClass.php
@@ -1,0 +1,29 @@
+<?php
+namespace Aura\Di\Fake;
+
+use Aura\Di\Container;
+use Aura\Di\Injection\MutationInterface;
+
+class FakeMutationWithDependencyClass implements MutationInterface
+{
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     *
+     * Invokes the Mutation to return an object.
+     *
+     * @param object|FakeInterfaceClass $object
+     *
+     * @return object
+     */
+    public function __invoke(object $object): object
+    {
+        $object->setFoo($this->container->get('service'));
+        return $object;
+    }
+}


### PR DESCRIPTION
Adds a new feature. Allows class to be mutated after initialization. It can be seen as an abstracter method to modify the object after initialization compared to setters.

```php
$di->mutations['Vendor\Package\Example'][] = $di->lazyNew(ExampleMutation::class);

class ExampleMutation implements MutationInterface
{
    public function __invoke(object $object): object
    {
        $object->setFoo('mutated');
        return $object;
    }
}
```