### PR TITLE
Allow 7.4 snapshot and nightly failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ php:
   - 7.2
   - 7.3
   - 7.4snapshot
+  - nightly
+matrix:
+  allow_failures:
+    - php: 7.4snapshot
+    - php: nightly
 before_script:
   - composer self-update
   - composer install


### PR DESCRIPTION
Because 7.4 is now build against [oniguruma](https://github.com/travis-ci/php-src-builder/pull/36) and the Travis image is not updated for that, builds for 7.4 are failing. But 7.4 should be able to fail anyhow because it is not stable/released.