### PR TITLE
Ugrade packages and add PHP 8 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 5.0.0
+
+- (CHG) Upgrade to PHP 7.4+ and PHP 8.0
+- (CHG) Upgrade psr/container to ^2.0
+- (CHG) Upgrade phpunit to ^9.5
+- (CHG) Resolver now checks if class exists before calling get_parent_class
+- (CHG) Wrapped ReflectionClass calls in a try catch
+- (CHG) Removed acclimate/container.
+- (ADD) Replace acclimate/container with CompositeContainer
+
 ## 4.1.0
 
 - (ADD) Support 7.4

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
-        "psr/container": "^1.0"
+        "php": "^7.4|^8.0",
+        "psr/container": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,9 +27,9 @@
         }
     },
     "require-dev": {
-        "acclimate/container": "^2",
-        "phpunit/phpunit": "^8",
-        "producer/producer": "^2.3"
+        "producer/producer": "^2.3",
+        "phpunit/phpunit": "^9.5",
+        "roave/security-advisories": "dev-master"
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,13 @@
-<phpunit bootstrap="./phpunit.php"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
-
-    <testsuites>
-        <testsuite name="unit tests">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./phpunit.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit tests">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Resolver/AutoResolver.php
+++ b/src/Resolver/AutoResolver.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Aura\Di\Resolver;
 
 use Aura\Di\Injection\LazyNew;
+use ReflectionClass;
+use ReflectionException;
 use ReflectionParameter;
 
 /**
@@ -56,8 +58,18 @@ class AutoResolver extends Resolver
             return $unified;
         }
 
-        // use an explicit auto-resolution?
-        $rtype = $rparam->getClass();
+        try {
+            $rtype = $rparam->getType()
+                ? new ReflectionClass($rparam->getType()->getName())
+                : null ;
+        } catch (ReflectionException $re) {
+            if (str_ends_with($re->getMessage(), 'does not exist')) {
+                $rtype = null;
+            } else {
+                throw $re;
+            }
+        }
+
         if ($rtype && isset($this->types[$rtype->name])) {
             return $this->types[$rtype->name];
         }

--- a/src/Resolver/AutoResolver.php
+++ b/src/Resolver/AutoResolver.php
@@ -63,7 +63,12 @@ class AutoResolver extends Resolver
                 ? new ReflectionClass($rparam->getType()->getName())
                 : null ;
         } catch (ReflectionException $re) {
-            if (str_ends_with($re->getMessage(), 'does not exist')) {
+            if (0 === substr_compare(
+                $re->getMessage(),
+                'does not exist',
+                -\strlen('does not exist')
+            )
+            ) {
                 $rtype = null;
             } else {
                 throw $re;

--- a/src/Resolver/Blueprint.php
+++ b/src/Resolver/Blueprint.php
@@ -13,6 +13,7 @@ use Aura\Di\Exception;
 use Aura\Di\Injection\LazyInterface;
 use Aura\Di\Injection\MutationInterface;
 use ReflectionClass;
+use function array_values;
 
 final class Blueprint
 {
@@ -96,7 +97,7 @@ final class Blueprint
 
                     return $val;
                 },
-                $this->params
+                array_values($this->params)
             )
         );
 

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -11,6 +11,8 @@ namespace Aura\Di\Resolver;
 
 use Aura\Di\Exception;
 use ReflectionParameter;
+use function class_exists;
+use function get_parent_class;
 
 /**
  *
@@ -206,7 +208,7 @@ class Resolver
         }
 
         // fetch the values for parents so we can inherit them
-        $parent = get_parent_class($class);
+        $parent = class_exists($class) ? get_parent_class($class) : null;
         if ($parent) {
             $spec = $this->getUnified($parent);
         } else {

--- a/tests/CompositeContainer.php
+++ b/tests/CompositeContainer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Aura\Di;
+
+use Exception;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use function sprintf;
+
+class CompositeContainer implements ContainerInterface
+{
+    /**
+     * @var array Containers that are contained within this composite container
+     */
+    private $containers = array();
+
+    /**
+     * @param array $containers Containers to add to this composite container
+     */
+    public function __construct(array $containers = array())
+    {
+        foreach ($containers as $container) {
+            $this->addContainer($container);
+        }
+    }
+
+    /**
+     * Adds a container to an internal queue of containers
+     *
+     * @param ContainerInterface $container The container to add
+     *
+     * @return $this
+     */
+    public function addContainer(ContainerInterface $container)
+    {
+        $this->containers[] = $container;
+
+        return $this;
+    }
+
+    /** {@inheritDoc} */
+    public function get(string $id) {
+        /** @var ContainerInterface $container */
+        foreach ($this->containers as $container) {
+            if ($container->has($id)) {
+                return $container->get($id);
+            }
+        }
+
+        throw new Exception(sprintf('Entry with id [%s] not found.', $id));
+    }
+
+    /** {@inheritDoc} */
+    public function has(string $id): bool {
+        /** @var ContainerInterface $container */
+        foreach ($this->containers as $container) {
+            if ($container->has($id)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Di;
 
-use Acclimate\Container\CompositeContainer;
+use Aura\Di\CompositeContainer;
 use Aura\Di\Fake\FakeMutationClass;
 use Aura\Di\Fake\FakeMutationWithDependencyClass;
 use Aura\Di\Fake\FakeOtherClass;

--- a/tests/MinimalContainer.php
+++ b/tests/MinimalContainer.php
@@ -33,7 +33,7 @@ class MinimalContainer implements ContainerInterface
         throw new class extends \UnexpectedValueException implements NotFoundExceptionInterface {};
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return isset($this->collection[$id]);
     }


### PR DESCRIPTION
This PR addresses a few issues regarding exceptions thrown by `get_parent_class` and `ReflectionClass`.

As `get_parent_class` throws an error if the class names is malformed and/or does not exist, I have added a `class_exists`  check before passing the class name to  `get_parent_class`

This PR does not introduce any breaking changes. Although PHP 8 is support it uses nothing PHP 8 specific. 