### PR TITLE
use 7.2 onwards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.2', '7.3', '7.4', '8.0']
 
     steps:
       - name: Set up PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
 
     steps:
       - name: Set up PHP

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,10 +1,8 @@
+build:
+    nodes:
+        analysis:
+            tests:
+                override:
+                    - php-scrutinizer-run
 filter:
     paths: ["src/*"]
-tools:
-    external_code_coverage: true
-    php_code_coverage: true
-    php_sim: true
-    php_mess_detector: true
-    php_pdepend: true
-    php_analyzer: true
-    php_cpd: true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alternatively, [download a release][], or clone this repository, then map the
 
 ## Dependencies
 
-This package requires PHP 7.4 or later. We recommend using the latest available version of PHP as a matter of
+This package requires PHP 7.2 or later. We recommend using the latest available version of PHP as a matter of
 principle. If you are interested in using this package for older PHP versions, use version 3.x for PHP 5.5+.
 
 Aura library packages may sometimes depend on external interfaces, but never on

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "require-dev": {
         "producer/producer": "^2.3",
         "yoast/phpunit-polyfills": "^1.0",
+        "phpunit/phpunit": ">=8.0",
         "roave/security-advisories": "dev-master"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "psr/container": "^1.1.1 || ^2.0.2"
     },
     "autoload": {
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "producer/producer": "^2.3",
-        "phpunit/phpunit": "^9.5",
+        "yoast/phpunit-polyfills": "^1.0",
         "roave/security-advisories": "dev-master"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "producer/producer": "^2.3",
         "yoast/phpunit-polyfills": "^1.0",
-        "phpunit/phpunit": ">=8.0",
+        "phpunit/phpunit": "^8.0 || ^9.0",
         "roave/security-advisories": "dev-master"
     },
     "autoload-dev": {

--- a/tests/AbstractContainerConfigTest.php
+++ b/tests/AbstractContainerConfigTest.php
@@ -8,7 +8,7 @@
  */
 namespace Aura\Di;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  *
@@ -36,7 +36,7 @@ abstract class AbstractContainerConfigTest extends TestCase
      * @return null
      *
      */
-    protected function setUp(): void
+    protected function set_up()
     {
         $builder = new ContainerBuilder();
         $this->di = $builder->newConfiguredInstance(

--- a/tests/ContainerBuilderTest.php
+++ b/tests/ContainerBuilderTest.php
@@ -2,7 +2,7 @@
 namespace Aura\Di;
 
 use Aura\Di\Fake\FakeParentClass;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class ContainerBuilderTest extends TestCase
 {
@@ -11,9 +11,9 @@ class ContainerBuilderTest extends TestCase
      */
     protected $builder;
 
-    protected function setUp(): void
+    protected function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->builder = new ContainerBuilder();
     }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -11,7 +11,7 @@ use Aura\Di\Resolver\Blueprint;
 use Aura\Di\Resolver\Reflector;
 use Aura\Di\Resolver\Resolver;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class ContainerTest extends TestCase
 {
@@ -20,9 +20,9 @@ class ContainerTest extends TestCase
      */
     protected $container;
 
-    protected function setUp(): void
+    protected function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $builder = new ContainerBuilder;
         $this->container = $builder->newInstance();
     }

--- a/tests/Injection/FactoryTest.php
+++ b/tests/Injection/FactoryTest.php
@@ -4,7 +4,7 @@ namespace Aura\Di\Injection;
 use Aura\Di\Resolver\Blueprint;
 use Aura\Di\Resolver\Resolver;
 use Aura\Di\Resolver\Reflector;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class FactoryTest extends TestCase
 {
@@ -12,9 +12,9 @@ class FactoryTest extends TestCase
 
     protected $config;
 
-    protected function setUp(): void
+    protected function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->resolver = new Resolver(new Reflector());
     }
 

--- a/tests/Injection/LazyIncludeTest.php
+++ b/tests/Injection/LazyIncludeTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Di\Injection;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class LazyIncludeTest extends TestCase
 {

--- a/tests/Injection/LazyRequireTest.php
+++ b/tests/Injection/LazyRequireTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Di\Injection;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class LazyRequireTest extends TestCase
 {

--- a/tests/ResolutionHelperTest.php
+++ b/tests/ResolutionHelperTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Di;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class ResolutionHelperTest extends TestCase
 {
@@ -9,9 +9,9 @@ class ResolutionHelperTest extends TestCase
 
     protected $helper;
 
-    protected function setUp(): void
+    protected function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->container = $this->getMockBuilder(Container::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Resolver/AutoResolverTest.php
+++ b/tests/Resolver/AutoResolverTest.php
@@ -13,9 +13,9 @@ class AutoResolverTest extends ResolverTest
      */
     protected $resolver;
 
-    protected function setUp(): void
+    protected function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->resolver = new AutoResolver(new Reflector());
     }
 

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -2,7 +2,7 @@
 namespace Aura\Di\Resolver;
 
 use Aura\Di\Injection\Lazy;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class ResolverTest extends TestCase
 {
@@ -11,9 +11,9 @@ class ResolverTest extends TestCase
      */
     protected $resolver;
 
-    protected function setUp(): void
+    protected function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->resolver = new Resolver(new Reflector());
     }
 


### PR DESCRIPTION
Hi @frederikbosch ,

In PR https://github.com/auraphp/Aura.Di/pull/203 the php version was raised. But according to the principles of Aura if we raise the php version we should consider it as a major one.

Even though the 7.4 is in security mode we should consider people who have started using it from 7.2.

As there is no BC break in that PR apart from the php version, we should keep the CI and change the composer.json .

Please do consider this.

Thank you