### PR TITLE
initial design of using attributes for injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0",
         "psr/container": "^1.1.1 || ^2.0.2"
     },
     "autoload": {

--- a/src/Attribute/Instance.php
+++ b/src/Attribute/Instance.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+
+namespace Aura\Di\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Instance
+{
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Attribute/Service.php
+++ b/src/Attribute/Service.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+
+namespace Aura\Di\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Service
+{
+    private string $name;
+
+    public function __construct(string $name, ?string $methodName = null, ...$params)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Attribute/Value.php
+++ b/src/Attribute/Value.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+
+namespace Aura\Di\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Value
+{
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fake/FakeConstructAttributeClass.php
+++ b/tests/Fake/FakeConstructAttributeClass.php
@@ -1,0 +1,38 @@
+<?php
+namespace Aura\Di\Fake;
+
+use Aura\Di\Attribute\Instance;
+use Aura\Di\Attribute\Service;
+use Aura\Di\Attribute\Value;
+
+class FakeConstructAttributeClass
+{
+    private FakeInterface $fakeService;
+    private FakeInterface $fakeServiceGet;
+    private FakeInterface $fakeInstance;
+    private FakeInterface $fakeSetter;
+    private string $string;
+
+    public function __construct(
+        #[Service('fake.service')]
+        FakeInterface $fakeService,
+        #[Service('fake.service', 'getFoo')]
+        FakeInterface $fakeServiceGet,
+        #[Instance(FakeInterfaceClass1::class)]
+        FakeInterface $fakeInstance,
+        #[Value('fake.value')]
+        string $string,
+    ) {
+        $this->fakeService = $fakeService;
+        $this->fakeServiceGet = $fakeServiceGet;
+        $this->fakeInstance = $fakeInstance;
+        $this->string = $string;
+    }
+
+    public function setFake(
+        #[Service('fake.setter')]
+        FakeInterface $fakeSetter
+    ) {
+        $this->fakeSetter = $fakeSetter;
+    }
+}


### PR DESCRIPTION
```php
use Aura\Di\Attribute\Instance;
use Aura\Di\Attribute\Service;
use Aura\Di\Attribute\Value;

class FakeConstructAttributeClass
{
    private FakeInterface $fakeSetter;

    public function __construct(
        #[Service('fake.service')]
        private FakeInterface $fakeService,
        #[Service('fake.service', 'getFoo')]
        private FakeInterface $fakeServiceGet,
        #[Instance(FakeInterfaceClass1::class)]
        private FakeInterface $fakeInstance,
        #[Value('fake.value')]
        private string $string,
    ) {
    }

    public function setFake(
        #[Service('fake.setter')]
        FakeInterface $fakeSetter
    ) {
        $this->fakeSetter = $fakeSetter;
    }
}
```

Design choices:

- All attributes define lazy injections
- Attributes will have the lowest precedence, e.g. `->params[FakeConstructAttributeClass::class]['fakeService'] = ...` will overwrite the attribute.

Limitations:

- You cannot pass `params` to `#[Instance]` attributes. If you want to overwrite constructor parameters of an injected instance, you would have to change to an `#[Service]` attribute or reside to inject by code. 
```php
$container->params[FakeConstructAttributeClass::class]['fakeService'] = $container->lazyNew(MyClass, [
    'param1' => $container->lazyGet('service')
]);
```
- You cannot pass `params` to `#[Service('service', 'method')]` attributes. You would have to reside to the method using code, or define an additional service and then use `#[Service('new.service)]`.
```php
$container->set('new.service', $container->lazyGetCall('service', 'method', $container->lazyNew(OtherClass::class))
```

I will continue with the implementation if there is no objection towards this direction. I will take at least a week before continuing.