### PR TITLE
Drop sec advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     "require-dev": {
         "producer/producer": "^2.3",
         "yoast/phpunit-polyfills": "^1.0",
-        "phpunit/phpunit": "^8.0 || ^9.0",
-        "roave/security-advisories": "dev-master"
+        "phpunit/phpunit": "^8.0 || ^9.0"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Composer has security auditing built in for quite a while now. We can safely drop `roave/security-advisories`.