### PR TITLE
AnnotatedInjectAttributeConfig should only mark for blueprint creation

### DIFF
--- a/src/ClassScanner/AnnotatedInjectAttributeConfig.php
+++ b/src/ClassScanner/AnnotatedInjectAttributeConfig.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Aura\Di\ClassScanner;
 
-use Aura\Di\Attribute\AnnotatedInjectInterface;
 use Aura\Di\Container;
 
 final class AnnotatedInjectAttributeConfig implements AttributeConfigInterface
@@ -18,9 +17,7 @@ final class AnnotatedInjectAttributeConfig implements AttributeConfigInterface
     public static function define(Container $di, AttributeSpecification $attribute, ClassSpecification $class): void
     {
         if ($attribute->isConstructorParameterAttribute()) {
-            /** @var AnnotatedInjectInterface $annotatedInject */
-            $annotatedInject = $attribute->getAttributeInstance();
-            $di->params[$attribute->getClassName()][$attribute->getTargetParameter()] = $annotatedInject->inject();
+            $di->params[$attribute->getClassName()] = $di->params[$attribute->getClassName()] ?? [];;
         }
     }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -489,7 +489,9 @@ class Container implements ContainerInterface
      * Note the that container must be locked before creating a new instance.
      * This prevents premature resolution of params and setters.
      *
-     * @param string $class The class to instantiate.
+     * @phpstan-template T
+     *
+     * @param class-string<T> $class The class to instantiate.
      *
      * @param array $mergeParams An array of override parameters; the key may
      * be the name *or* the numeric position of the constructor parameter, and
@@ -499,7 +501,7 @@ class Container implements ContainerInterface
      * name of the setter method to call and the value is the value to be
      * passed to the setter method.
      *
-     * @return object
+     * @return object&T
      *
      */
     public function newInstance(

--- a/tests/ClassScanner/ClassScannerConfigTest.php
+++ b/tests/ClassScanner/ClassScannerConfigTest.php
@@ -2,6 +2,8 @@
 namespace Aura\Di\ClassScanner;
 
 use Aura\Di\Container;
+use Aura\Di\Fake\FakeCompilationTestConfig;
+use Aura\Di\Fake\FakeConstructAttributeClass;
 use Aura\Di\Fake\FakeControllerClass;
 use Aura\Di\Fake\FakeInjectAnnotatedWithClass;
 use Aura\Di\Resolver\Reflector;
@@ -32,7 +34,7 @@ class ClassScannerConfigTest extends TestCase
 
         $annotation = $container->values['worker'][0];
         $this->assertSame(3, $annotation['someSetting']);
-        $this->assertSame('Aura\Di\Fake\FakeConstructAttributeClass', $annotation['className']);
+        $this->assertSame(FakeConstructAttributeClass::class, $annotation['className']);
 
         /** @var FakeInjectAnnotatedWithClass $injectedWith */
         $injectedWith = $container->newInstance(FakeInjectAnnotatedWithClass::class);
@@ -47,5 +49,19 @@ class ClassScannerConfigTest extends TestCase
         $this->config->define($container);
 
         $this->assertTrue(\array_key_exists(FakeControllerClass::class, $resolver->params));
+    }
+
+    public function testOrder()
+    {
+        $resolver = new Resolver(new Reflector());
+        $container = new Container($resolver);
+        $container->params[FakeConstructAttributeClass::class]['string'] = 'this_value_should_override_the_attribute';
+
+        $testConfig = new FakeCompilationTestConfig();
+        $testConfig->define($container);
+        $this->config->define($container);
+
+        $instance = $container->newInstance(FakeConstructAttributeClass::class);
+        $this->assertSame('this_value_should_override_the_attribute', $instance->getString());
     }
 }


### PR DESCRIPTION
Code definitions are executed _after_ attribute injections, and give the opportunity the override the attribute. This is already correctly documented.