### PR TITLE
fix auto resolver not resolving union type

### DIFF
--- a/src/Resolver/AutoResolver.php
+++ b/src/Resolver/AutoResolver.php
@@ -14,6 +14,7 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionNamedType;
 use ReflectionParameter;
+use ReflectionUnionType;
 
 /**
  *
@@ -59,19 +60,22 @@ class AutoResolver extends Resolver
             return $unified;
         }
 
+        $rtype = null;
+
         try {
-            $rtype = $rparam->getType() instanceof ReflectionNamedType
-                ? new ReflectionClass($rparam->getType()->getName())
-                : null ;
+            $paramType = $rparam->getType();
+            if ($paramType instanceof ReflectionNamedType) {
+                $rtype = new ReflectionClass($paramType->getName());
+            } elseif ($paramType instanceof ReflectionUnionType) {
+                foreach ($paramType->getTypes() as $individualType) {
+                    if ($individualType instanceof ReflectionNamedType) {
+                        $rtype = new ReflectionClass($individualType->getName());
+                        break;
+                    }
+                }
+            }
         } catch (ReflectionException $re) {
-            if (0 === substr_compare(
-                $re->getMessage(),
-                'does not exist',
-                -\strlen('does not exist')
-            )
-            ) {
-                $rtype = null;
-            } else {
+            if (0 !== substr_compare($re->getMessage(), 'does not exist', -\strlen('does not exist'))) {
                 throw $re;
             }
         }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -705,6 +705,16 @@ class ContainerTest extends TestCase
         $this->assertSame(3, $actual->second);
     }
 
+    public function testContainerUnionTypes()
+    {
+        $container = new Container(new Resolver(new Reflector()));
+        $container->params['Aura\Di\Fake\FakeChildClassWithUnionTypeParam'][] = '2026-06-16 12:00:00';
+
+        $actual = $container->newInstance('Aura\Di\Fake\FakeChildClassWithUnionTypeParam');
+
+        $this->assertSame('2026-06-16 12:00:00', $actual->moment->format('Y-m-d H:i:s'));
+    }
+
     public function testContextualParams()
     {
         $this->container->params['Aura\Di\Fake\FakeClassNeedsContextA']['fake'] = $this->container->lazyNew('Aura\Di\Fake\FakeClassNeedsContextB');

--- a/tests/Fake/FakeChildClassWithUnionTypeParam.php
+++ b/tests/Fake/FakeChildClassWithUnionTypeParam.php
@@ -1,0 +1,16 @@
+<?php
+namespace Aura\Di\Fake;
+
+class FakeChildClassWithUnionTypeParam
+{
+    public \DateTimeImmutable $moment;
+
+    public function __construct(\DateTimeImmutable|string $moment)
+    {
+        if (\is_string($moment)) {
+            $moment = new \DateTimeImmutable($moment);
+        }
+
+        $this->moment = $moment;
+    }
+}

--- a/tests/Resolver/AutoResolverTest.php
+++ b/tests/Resolver/AutoResolverTest.php
@@ -55,4 +55,12 @@ class AutoResolverTest extends ResolverTest
         $actual = $container->newInstance('Aura\Di\Fake\FakeClassWithDefaultParamInConstructor');
         $this->assertNull($actual->fake);
     }
+
+    public function testContainerUnionTypes()
+    {
+        $container = new Container(new AutoResolver(new Reflector()));
+        $container->newInstance('Aura\Di\Fake\FakeChildClassWithUnionTypeParam');
+
+        $this->addToAssertionCount(1);
+    }
 }


### PR DESCRIPTION
Fixes #231 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PHP union types in constructor parameter auto-resolution. The auto-resolver now correctly handles constructor parameters declared with union types, improving type detection during automatic dependency injection.

* **Tests**
  * Added test coverage for union type parameter resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->